### PR TITLE
Migrate to inworld-tts-2 + Soniox STT, add 54 languages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Language learning app using Inworld Realtime API for voice conversations.
 ## Architecture
 Browser <-> our WebSocket <-> SessionManager <-> Inworld Realtime WebSocket (STT+LLM+TTS)
 - STT model: assemblyai/u3-rt-pro (with per-language hints)
-- LLM model: openai/gpt-4.1-nano (via Inworld Realtime)
+- LLM model: openai/gpt-5.4-mini (via Inworld Realtime)
 - SessionManager: one per client, manages Inworld WS lifecycle, forwards audio/text, handles greeting, tracks turns
 - InworldLLM: uses Inworld LLM Router (OpenAI-compatible) for flashcards, feedback, translation
 - TurnMemory: 5-turn sliding window, non-blocking Supabase persistence

--- a/backend/src/__tests__/config/languages.test.ts
+++ b/backend/src/__tests__/config/languages.test.ts
@@ -55,6 +55,8 @@ describe('languages config', () => {
         expect(config.teacherPersona).toBeDefined();
         expect(config.teacherPersona.name).toBeTruthy();
         expect(config.exampleTopics.length).toBeGreaterThan(0);
+        expect(Array.isArray(config.disfluencies)).toBe(true);
+        expect(config.disfluencies.length).toBeGreaterThanOrEqual(1);
       }
     });
   });

--- a/backend/src/__tests__/config/languages.test.ts
+++ b/backend/src/__tests__/config/languages.test.ts
@@ -48,7 +48,7 @@ describe('languages config', () => {
         expect(config.name).toBeTruthy();
         expect(config.nativeName).toBeTruthy();
         expect(config.flag).toBeTruthy();
-        expect(config.sttLanguageCode).toBeTruthy();
+        expect(config.bcp47).toBeTruthy();
         expect(config.ttsConfig).toBeDefined();
         expect(config.ttsConfig.speakerId).toBeTruthy();
         expect(config.ttsConfig.modelId).toBeTruthy();

--- a/backend/src/__tests__/inworld-llm.test.ts
+++ b/backend/src/__tests__/inworld-llm.test.ts
@@ -295,7 +295,7 @@ describe('InworldLLM', () => {
         json: async () => ({ audioContent: 'base64audiodata==' }),
       } as Response);
 
-      const audio = await llm.pronounce('Hola', 'Rafael');
+      const audio = await llm.pronounce('Hola', 'Rafael', 'es-MX');
       expect(audio).toBe('base64audiodata==');
     });
 
@@ -305,7 +305,7 @@ describe('InworldLLM', () => {
         json: async () => ({ audioContent: 'audio' }),
       } as Response);
 
-      await llm.pronounce('perro', 'Rafael');
+      await llm.pronounce('perro', 'Rafael', 'es-MX');
 
       expect(fetchSpy).toHaveBeenCalledWith(
         'https://api.inworld.ai/tts/v1/voice',
@@ -315,7 +315,8 @@ describe('InworldLLM', () => {
       const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
       expect(body.text).toBe('perro');
       expect(body.voice_id).toBe('Rafael');
-      expect(body.model_id).toBe('inworld-tts-1.5-max');
+      expect(body.model_id).toBe('inworld-tts-2');
+      expect(body.language).toBe('es-MX');
       expect(body.audio_config.audio_encoding).toBe('LINEAR16');
       expect(body.audio_config.sample_rate_hertz).toBe(24000);
     });
@@ -326,7 +327,7 @@ describe('InworldLLM', () => {
         status: 500,
       } as Response);
 
-      const audio = await llm.pronounce('Hola', 'Rafael');
+      const audio = await llm.pronounce('Hola', 'Rafael', 'es-MX');
       expect(audio).toBeNull();
     });
 
@@ -334,7 +335,7 @@ describe('InworldLLM', () => {
       process.env.INWORLD_API_KEY = '';
       const noKeyLlm = new InworldLLM();
 
-      const audio = await noKeyLlm.pronounce('Hola', 'Rafael');
+      const audio = await noKeyLlm.pronounce('Hola', 'Rafael', 'es-MX');
       expect(audio).toBeNull();
     });
   });

--- a/backend/src/__tests__/inworld-llm.test.ts
+++ b/backend/src/__tests__/inworld-llm.test.ts
@@ -252,7 +252,7 @@ describe('InworldLLM', () => {
       );
 
       const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
-      expect(body.model).toBe('openai/gpt-4.1-nano');
+      expect(body.model).toBe('openai/gpt-5.4-mini');
       expect(body.messages[0].role).toBe('user');
       expect(body.max_tokens).toBeDefined();
       expect(body.temperature).toBeDefined();

--- a/backend/src/__tests__/inworld-llm.test.ts
+++ b/backend/src/__tests__/inworld-llm.test.ts
@@ -295,7 +295,12 @@ describe('InworldLLM', () => {
         json: async () => ({ audioContent: 'base64audiodata==' }),
       } as Response);
 
-      const audio = await llm.pronounce('Hola', 'Rafael', 'es-MX');
+      const audio = await llm.pronounce(
+        'Hola',
+        'Rafael',
+        'es-MX',
+        'inworld-tts-2'
+      );
       expect(audio).toBe('base64audiodata==');
     });
 
@@ -305,7 +310,7 @@ describe('InworldLLM', () => {
         json: async () => ({ audioContent: 'audio' }),
       } as Response);
 
-      await llm.pronounce('perro', 'Rafael', 'es-MX');
+      await llm.pronounce('perro', 'Rafael', 'es-MX', 'inworld-tts-2');
 
       expect(fetchSpy).toHaveBeenCalledWith(
         'https://api.inworld.ai/tts/v1/voice',
@@ -327,7 +332,12 @@ describe('InworldLLM', () => {
         status: 500,
       } as Response);
 
-      const audio = await llm.pronounce('Hola', 'Rafael', 'es-MX');
+      const audio = await llm.pronounce(
+        'Hola',
+        'Rafael',
+        'es-MX',
+        'inworld-tts-2'
+      );
       expect(audio).toBeNull();
     });
 
@@ -335,7 +345,12 @@ describe('InworldLLM', () => {
       process.env.INWORLD_API_KEY = '';
       const noKeyLlm = new InworldLLM();
 
-      const audio = await noKeyLlm.pronounce('Hola', 'Rafael', 'es-MX');
+      const audio = await noKeyLlm.pronounce(
+        'Hola',
+        'Rafael',
+        'es-MX',
+        'inworld-tts-2'
+      );
       expect(audio).toBeNull();
     });
   });

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -471,7 +471,7 @@ describe('SessionManager', () => {
       );
       expect(sent.session.audio.input.transcription.language).toBe('es');
       expect(sent.session.providerData.tts.language).toBe('es-MX');
-      expect(sent.session.model).toBe('openai/gpt-4.1-nano');
+      expect(sent.session.model).toBe('openai/gpt-5.4-mini');
     });
 
     it('should strip steering and non-verbal tags from completed assistant transcript', () => {

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import WebSocket from 'ws';
-import { SessionManager } from '../services/session-manager.js';
+import {
+  SessionManager,
+  stripBracketedTags,
+} from '../services/session-manager.js';
 
 // Mock ws module so SessionManager doesn't make real connections
 vi.mock('ws', () => {
@@ -24,6 +27,40 @@ function createMockClientWs() {
     _messages: messages,
   } as unknown as WebSocket;
 }
+
+describe('stripBracketedTags', () => {
+  it('removes a leading steering tag and trims', () => {
+    expect(stripBracketedTags('[speak warmly] Hello there')).toBe(
+      'Hello there'
+    );
+  });
+
+  it('removes inline non-verbal tags', () => {
+    expect(stripBracketedTags('That is funny [laugh] really')).toBe(
+      'That is funny really'
+    );
+  });
+
+  it('collapses double spaces left by removed tags', () => {
+    expect(stripBracketedTags('one [tag] two')).toBe('one two');
+  });
+
+  it('removes the space before punctuation when a tag preceded it', () => {
+    expect(stripBracketedTags('Hello [laugh] , how are you')).toBe(
+      'Hello, how are you'
+    );
+  });
+
+  it('preserves disfluency text (no brackets) untouched', () => {
+    expect(stripBracketedTags('えーと、そうですね')).toBe('えーと、そうですね');
+  });
+
+  it('handles multiple bracketed tags in one string', () => {
+    expect(
+      stripBracketedTags('[speak gently] Pues [sigh] no sé qué decir')
+    ).toBe('Pues no sé qué decir');
+  });
+});
 
 describe('SessionManager', () => {
   const originalEnv = process.env.INWORLD_API_KEY;
@@ -435,6 +472,107 @@ describe('SessionManager', () => {
       expect(sent.session.audio.input.transcription.language).toBe('es');
       expect(sent.session.providerData.tts.language).toBe('es-MX');
       expect(sent.session.model).toBe('openai/gpt-4.1-nano');
+    });
+
+    it('should strip steering and non-verbal tags from completed assistant transcript', () => {
+      const clientWs = createMockClientWs();
+      const mgr = new SessionManager({
+        sessionId: 'test-strip-1',
+        ws: clientWs,
+        languageCode: 'ja',
+      });
+
+      const mgrAny = mgr as unknown as Record<string, unknown>;
+      mgrAny.sessionReady = true;
+
+      const handler = mgrAny.handleInworldEvent as (
+        event: Record<string, unknown>
+      ) => void;
+      handler.call(mgr, {
+        type: 'response.output_audio_transcript.done',
+        transcript:
+          '[speak gently] なるほど、忙しいですね。[laugh] 趣味はありますか？',
+      });
+
+      const sent = (clientWs as unknown as { _messages: string[] })._messages;
+      const completes = sent
+        .map((m) => JSON.parse(m))
+        .filter(
+          (m: Record<string, unknown>) => m.type === 'llm_response_complete'
+        );
+      expect(completes).toHaveLength(1);
+      expect(completes[0].text).not.toContain('[');
+      expect(completes[0].text).not.toContain(']');
+      expect(completes[0].text).toContain('なるほど');
+      expect(completes[0].text).toContain('趣味はありますか');
+    });
+
+    it('should strip a bracketed tag that straddles two streaming deltas', () => {
+      const clientWs = createMockClientWs();
+      const mgr = new SessionManager({
+        sessionId: 'test-strip-2',
+        ws: clientWs,
+        languageCode: 'es',
+      });
+
+      const mgrAny = mgr as unknown as Record<string, unknown>;
+      mgrAny.sessionReady = true;
+
+      const handler = mgrAny.handleInworldEvent as (
+        event: Record<string, unknown>
+      ) => void;
+
+      handler.call(mgr, {
+        type: 'response.output_audio_transcript.delta',
+        delta: 'Hola, [spe',
+      });
+      handler.call(mgr, {
+        type: 'response.output_audio_transcript.delta',
+        delta: 'ak warmly] ¿qué tal?',
+      });
+
+      const sent = (clientWs as unknown as { _messages: string[] })._messages;
+      const chunks = sent
+        .map((m) => JSON.parse(m))
+        .filter(
+          (m: Record<string, unknown>) => m.type === 'llm_response_chunk'
+        );
+      const concatenated = chunks.map((c) => c.text).join('');
+      expect(concatenated).not.toContain('[');
+      expect(concatenated).not.toContain(']');
+      expect(concatenated).toContain('Hola');
+      expect(concatenated).toContain('¿qué tal?');
+    });
+
+    it('should include TTS-2 expressivity guidance with steering, nonverbal, and target-language disfluencies', () => {
+      const clientWs = createMockClientWs();
+      const mgr = new SessionManager({
+        sessionId: 'test-expressivity-1',
+        ws: clientWs,
+        languageCode: 'es',
+      });
+
+      const mgrAny = mgr as unknown as Record<string, unknown>;
+      const mockInworldWs = {
+        readyState: 1,
+        send: vi.fn(),
+        on: vi.fn(),
+        close: vi.fn(),
+      };
+      mgrAny.inworldWs = mockInworldWs;
+
+      const sendUpdate = mgrAny.sendSessionUpdate as () => void;
+      sendUpdate.call(mgr);
+
+      const sent = JSON.parse(mockInworldWs.send.mock.calls[0][0]);
+      const instructions = sent.session.instructions as string;
+
+      // Steering tag example
+      expect(instructions).toContain('[speak');
+      // Non-verbal tag
+      expect(instructions).toContain('[laugh]');
+      // Spanish disfluency from the seeded list
+      expect(instructions).toContain('este');
     });
   });
 });

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -281,7 +281,7 @@ describe('SessionManager', () => {
   });
 
   describe('streaming STT events', () => {
-    it('should accumulate transcription deltas incrementally', () => {
+    it('should treat transcription deltas as cumulative (Soniox)', () => {
       const clientWs = createMockClientWs();
       const mgr = new SessionManager({
         sessionId: 'test-stt-1',
@@ -298,12 +298,12 @@ describe('SessionManager', () => {
 
       handler.call(mgr, {
         type: 'conversation.item.input_audio_transcription.delta',
-        delta: 'Hola, ',
+        delta: 'Hola',
       });
 
       handler.call(mgr, {
         type: 'conversation.item.input_audio_transcription.delta',
-        delta: 'me llamo Cale.',
+        delta: 'Hola, me llamo Cale.',
       });
 
       const sent = (clientWs as unknown as { _messages: string[] })._messages;
@@ -313,7 +313,7 @@ describe('SessionManager', () => {
           (m: Record<string, unknown>) => m.type === 'partial_transcript'
         );
       expect(partials).toHaveLength(2);
-      expect(partials[0].text).toBe('Hola, ');
+      expect(partials[0].text).toBe('Hola');
       expect(partials[1].text).toBe('Hola, me llamo Cale.');
     });
 
@@ -430,9 +430,10 @@ describe('SessionManager', () => {
       const sent = JSON.parse(mockInworldWs.send.mock.calls[0][0]);
       expect(sent.type).toBe('session.update');
       expect(sent.session.audio.input.transcription.model).toBe(
-        'assemblyai/u3-rt-pro'
+        'soniox/stt-rt-v4'
       );
-      expect(sent.session.audio.input.transcription.language).toBe('es-MX');
+      expect(sent.session.audio.input.transcription.language).toBe('es');
+      expect(sent.session.providerData.tts.language).toBe('es-MX');
       expect(sent.session.model).toBe('openai/gpt-4.1-nano');
     });
   });

--- a/backend/src/config/languages.ts
+++ b/backend/src/config/languages.ts
@@ -1,10 +1,15 @@
 /**
  * Language Configuration System
  *
- * This module provides a centralized configuration for all supported languages.
- * To add a new language:
- * 1. Add a new entry to SUPPORTED_LANGUAGES with all required fields
- * 2. The rest of the app will automatically support the new language
+ * Centralized configuration for all supported languages.
+ *
+ * Wire-format conventions:
+ * - `bcp47` is the canonical form ("es-ES", "fi-FI"). Used for TTS-2 via
+ *   `session.providerData.tts.language` (and the REST `/tts/v1/voice` `language` field).
+ * - `code` is ISO 639-1 ("es", "fi"). Used as the map key, dropdown value,
+ *   and Soniox STT hint via `transcription.language`.
+ *
+ * To add a new language: add a new entry to SUPPORTED_LANGUAGES.
  */
 
 import { createLogger } from '../utils/logger.js';
@@ -23,53 +28,42 @@ export interface TTSConfig {
   modelId: string;
   speakingRate: number;
   temperature: number;
-  languageCode?: string; // Optional TTS language code (e.g., 'ja-JP')
 }
 
 export interface LanguageConfig {
-  // Identifier
-  code: string; // e.g., 'es', 'ja', 'fr'
+  /** ISO 639-1 (e.g., 'es', 'ja', 'fr') — map key, dropdown value, Soniox STT hint. */
+  code: string;
+  /** BCP-47 with uppercase region (e.g., 'es-ES', 'fi-FI') — TTS-2 language hint. */
+  bcp47: string;
 
-  // Display names
   name: string; // English name: "Spanish"
   nativeName: string; // Native name: "Español"
   flag: string; // Emoji flag
 
-  // STT configuration
-  sttLanguageCode: string; // Language code for speech-to-text
-
-  // TTS configuration
   ttsConfig: TTSConfig;
-
-  // Teacher persona for this language
   teacherPersona: TeacherPersona;
-
-  // Example conversation topics specific to this language's culture
   exampleTopics: string[];
 }
 
 /**
  * Supported Languages Configuration
  *
- * Each language defines everything needed for:
- * - Speech recognition (STT)
- * - Text-to-speech (TTS)
- * - Teacher persona and conversation style
- * - Cultural context and example topics
+ * The first 6 entries are curated personas (existing). All other languages
+ * use Sarah/Jason TTS-2 voices alternated, with concise templated personas.
  */
 export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
+  // ── Curated languages ────────────────────────────────────────
   en: {
     code: 'en',
+    bcp47: 'en-US',
     name: 'English',
     nativeName: 'English',
     flag: '🇺🇸',
-    sttLanguageCode: 'en-US',
     ttsConfig: {
       speakerId: 'Lauren',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 1.1,
-      languageCode: 'en-US',
     },
     teacherPersona: {
       name: 'Ms. Sarah Mitchell',
@@ -89,16 +83,15 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
 
   es: {
     code: 'es',
+    bcp47: 'es-MX',
     name: 'Spanish',
     nativeName: 'Español',
     flag: '🇲🇽',
-    sttLanguageCode: 'es-MX', // Mexican Spanish
     ttsConfig: {
       speakerId: 'Rafael',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 1.1,
-      languageCode: 'es-MX',
     },
     teacherPersona: {
       name: 'Señor Gael Herrera',
@@ -118,16 +111,15 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
 
   fr: {
     code: 'fr',
+    bcp47: 'fr-FR',
     name: 'French',
     nativeName: 'Français',
     flag: '🇫🇷',
-    sttLanguageCode: 'fr-FR',
     ttsConfig: {
       speakerId: 'Alain',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 1.1,
-      languageCode: 'fr-FR',
     },
     teacherPersona: {
       name: 'Monsieur Lucien Dubois',
@@ -148,16 +140,15 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
 
   de: {
     code: 'de',
+    bcp47: 'de-DE',
     name: 'German',
     nativeName: 'Deutsch',
     flag: '🇩🇪',
-    sttLanguageCode: 'de-DE',
     ttsConfig: {
       speakerId: 'Josef',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 0.7,
-      languageCode: 'de-DE',
     },
     teacherPersona: {
       name: 'Herr Klaus Weber',
@@ -178,16 +169,15 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
 
   it: {
     code: 'it',
+    bcp47: 'it-IT',
     name: 'Italian',
     nativeName: 'Italiano',
     flag: '🇮🇹',
-    sttLanguageCode: 'it-IT',
     ttsConfig: {
       speakerId: 'Orietta',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 1.1,
-      languageCode: 'it-IT',
     },
     teacherPersona: {
       name: 'Signora Maria Rossi',
@@ -208,16 +198,15 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
 
   pt: {
     code: 'pt',
+    bcp47: 'pt-BR',
     name: 'Portuguese',
     nativeName: 'Português',
     flag: '🇧🇷',
-    sttLanguageCode: 'pt-BR', // Brazilian Portuguese
     ttsConfig: {
       speakerId: 'Heitor',
-      modelId: 'inworld-tts-1.5-max',
+      modelId: 'inworld-tts-2',
       speakingRate: 1,
       temperature: 0.7,
-      languageCode: 'pt-BR',
     },
     teacherPersona: {
       name: 'Senhor João Silva',
@@ -234,6 +223,925 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'football (soccer) culture',
       'the Amazon and Brazilian nature',
     ],
+  },
+
+  // ── Soniox-supported languages (alphabetical, alternating Sarah/Jason) ─
+  af: {
+    code: 'af',
+    bcp47: 'af-ZA',
+    name: 'Afrikaans',
+    nativeName: 'Afrikaans',
+    flag: '🇿🇦',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Pieter',
+      age: 36,
+      nationality: 'South African',
+      description:
+        'a South African tutor who loves teaching Afrikaans through Cape Town life, braai culture, and Karoo road trips',
+    },
+    exampleTopics: ['Cape Town and Table Mountain', 'braai culture and South African food', 'Afrikaans music and writers'],
+  },
+
+  sq: {
+    code: 'sq',
+    bcp47: 'sq-AL',
+    name: 'Albanian',
+    nativeName: 'Shqip',
+    flag: '🇦🇱',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Arta',
+      age: 32,
+      nationality: 'Albanian',
+      description:
+        'an Albanian tutor passionate about Tirana, the Albanian Riviera, and traditional cuisine',
+    },
+    exampleTopics: ['Tirana street life', 'the Albanian Riviera and Ksamil', 'traditional dishes like tavë kosi'],
+  },
+
+  ar: {
+    code: 'ar',
+    bcp47: 'ar-SA',
+    name: 'Arabic',
+    nativeName: 'العربية',
+    flag: '🇸🇦',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Layla',
+      age: 33,
+      nationality: 'Saudi',
+      description:
+        'a Saudi tutor who loves teaching Arabic through Middle Eastern history, classical poetry, and modern culture',
+    },
+    exampleTopics: ['Arabic poetry and proverbs', 'food across the Levant and Gulf', 'travel to Petra, Cairo, and Riyadh'],
+  },
+
+  az: {
+    code: 'az',
+    bcp47: 'az-AZ',
+    name: 'Azerbaijani',
+    nativeName: 'Azərbaycanca',
+    flag: '🇦🇿',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Elmira',
+      age: 34,
+      nationality: 'Azerbaijani',
+      description:
+        'an Azerbaijani tutor who loves Baku, the Caspian coast, and Caucasus cuisine',
+    },
+    exampleTopics: ['Baku old city and modern skyline', 'plov and traditional Azerbaijani food', 'mugham music'],
+  },
+
+  eu: {
+    code: 'eu',
+    bcp47: 'eu-ES',
+    name: 'Basque',
+    nativeName: 'Euskara',
+    flag: '🏴',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Iker',
+      age: 35,
+      nationality: 'Basque',
+      description:
+        'a Basque tutor who loves teaching Euskara through San Sebastián pintxos and Bilbao culture',
+    },
+    exampleTopics: ['pintxo bars in Donostia', 'the Guggenheim and Bilbao', 'Basque mythology and rural life'],
+  },
+
+  be: {
+    code: 'be',
+    bcp47: 'be-BY',
+    name: 'Belarusian',
+    nativeName: 'Беларуская',
+    flag: '🇧🇾',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Hanna',
+      age: 31,
+      nationality: 'Belarusian',
+      description:
+        'a Belarusian tutor passionate about Minsk, traditional folk songs, and Belarusian literature',
+    },
+    exampleTopics: ['Minsk and Belarusian cities', 'draniki and traditional cuisine', 'Belarusian folk music'],
+  },
+
+  bn: {
+    code: 'bn',
+    bcp47: 'bn-BD',
+    name: 'Bengali',
+    nativeName: 'বাংলা',
+    flag: '🇧🇩',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Anika',
+      age: 30,
+      nationality: 'Bangladeshi',
+      description:
+        'a Bangladeshi tutor who loves teaching Bengali through Dhaka life, Tagore poetry, and the Sundarbans',
+    },
+    exampleTopics: ['Dhaka street food', 'Tagore and Bengali literature', 'Sundarbans and rural Bengal'],
+  },
+
+  bs: {
+    code: 'bs',
+    bcp47: 'bs-BA',
+    name: 'Bosnian',
+    nativeName: 'Bosanski',
+    flag: '🇧🇦',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Edin',
+      age: 37,
+      nationality: 'Bosnian',
+      description:
+        'a Bosnian tutor passionate about Sarajevo, ćevapi, and Balkan history',
+    },
+    exampleTopics: ['Sarajevo old town', 'ćevapi and Bosnian cuisine', 'Mostar and the Stari Most bridge'],
+  },
+
+  bg: {
+    code: 'bg',
+    bcp47: 'bg-BG',
+    name: 'Bulgarian',
+    nativeName: 'Български',
+    flag: '🇧🇬',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Boyana',
+      age: 33,
+      nationality: 'Bulgarian',
+      description:
+        'a Bulgarian tutor who loves Sofia, Rila monasteries, and Black Sea summers',
+    },
+    exampleTopics: ['Sofia and the Vitosha mountains', 'banitsa and shopska salad', 'Bulgarian folk music and dance'],
+  },
+
+  ca: {
+    code: 'ca',
+    bcp47: 'ca-ES',
+    name: 'Catalan',
+    nativeName: 'Català',
+    flag: '🏴',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Jordi',
+      age: 36,
+      nationality: 'Catalan',
+      description:
+        'a Catalan tutor who loves Barcelona, Gaudí, and Mediterranean coastal life',
+    },
+    exampleTopics: ['Barcelona neighborhoods', 'castellers and Catalan traditions', 'pa amb tomàquet and Catalan food'],
+  },
+
+  zh: {
+    code: 'zh',
+    bcp47: 'zh-CN',
+    name: 'Chinese',
+    nativeName: '中文',
+    flag: '🇨🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Mei',
+      age: 32,
+      nationality: 'Chinese',
+      description:
+        'a Beijing tutor who loves teaching Mandarin through tea culture, classical poetry, and modern Chinese cinema',
+    },
+    exampleTopics: ['Beijing hutongs and street food', 'Chinese tea culture', 'classical poetry and modern films'],
+  },
+
+  hr: {
+    code: 'hr',
+    bcp47: 'hr-HR',
+    name: 'Croatian',
+    nativeName: 'Hrvatski',
+    flag: '🇭🇷',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Ivana',
+      age: 34,
+      nationality: 'Croatian',
+      description:
+        'a Croatian tutor passionate about Dubrovnik, Dalmatian islands, and Adriatic seafood',
+    },
+    exampleTopics: ['Dalmatian coast and islands', 'Plitvice Lakes', 'peka and Croatian seafood'],
+  },
+
+  cs: {
+    code: 'cs',
+    bcp47: 'cs-CZ',
+    name: 'Czech',
+    nativeName: 'Čeština',
+    flag: '🇨🇿',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Pavel',
+      age: 38,
+      nationality: 'Czech',
+      description:
+        'a Czech tutor who loves teaching through Prague history, Bohemian beer halls, and Czech literature',
+    },
+    exampleTopics: ['Prague castle and the old town', 'Czech pivo and beer culture', 'Kafka and Czech cinema'],
+  },
+
+  da: {
+    code: 'da',
+    bcp47: 'da-DK',
+    name: 'Danish',
+    nativeName: 'Dansk',
+    flag: '🇩🇰',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Mette',
+      age: 33,
+      nationality: 'Danish',
+      description:
+        'a Danish tutor passionate about Copenhagen, hygge, and Nordic design',
+    },
+    exampleTopics: ['Copenhagen and Nyhavn', 'hygge and Scandinavian design', 'smørrebrød and new Nordic cuisine'],
+  },
+
+  nl: {
+    code: 'nl',
+    bcp47: 'nl-NL',
+    name: 'Dutch',
+    nativeName: 'Nederlands',
+    flag: '🇳🇱',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Sanne',
+      age: 31,
+      nationality: 'Dutch',
+      description:
+        'a Dutch tutor who loves teaching through Amsterdam canals, cycling culture, and Dutch design',
+    },
+    exampleTopics: ['Amsterdam canals and museums', 'cycling and Dutch daily life', 'stroopwafels and bitterballen'],
+  },
+
+  et: {
+    code: 'et',
+    bcp47: 'et-EE',
+    name: 'Estonian',
+    nativeName: 'Eesti',
+    flag: '🇪🇪',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Kaarel',
+      age: 34,
+      nationality: 'Estonian',
+      description:
+        'an Estonian tutor passionate about Tallinn old town, e-Estonia, and Baltic forests',
+    },
+    exampleTopics: ['Tallinn medieval old town', 'Estonian saunas and forest culture', 'e-Estonia and digital society'],
+  },
+
+  tl: {
+    code: 'tl',
+    bcp47: 'fil-PH',
+    name: 'Filipino',
+    nativeName: 'Filipino',
+    flag: '🇵🇭',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Liza',
+      age: 30,
+      nationality: 'Filipino',
+      description:
+        'a Filipino tutor who loves teaching Tagalog through Manila life, island hopping, and family traditions',
+    },
+    exampleTopics: ['Manila and Cebu', 'adobo and lechon', 'Philippine islands and beaches'],
+  },
+
+  fi: {
+    code: 'fi',
+    bcp47: 'fi-FI',
+    name: 'Finnish',
+    nativeName: 'Suomi',
+    flag: '🇫🇮',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Aino',
+      age: 33,
+      nationality: 'Finnish',
+      description:
+        'a Finnish tutor who loves teaching Finnish through Helsinki life and Nordic culture',
+    },
+    exampleTopics: ['sauna culture', 'Finnish design and architecture', 'life in Helsinki and Lapland'],
+  },
+
+  gl: {
+    code: 'gl',
+    bcp47: 'gl-ES',
+    name: 'Galician',
+    nativeName: 'Galego',
+    flag: '🏴',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Brais',
+      age: 36,
+      nationality: 'Galician',
+      description:
+        'a Galician tutor passionate about Santiago de Compostela, Atlantic coast, and Galician seafood',
+    },
+    exampleTopics: ['Camino de Santiago', 'pulpo a la gallega and seafood', 'Galician folk music'],
+  },
+
+  el: {
+    code: 'el',
+    bcp47: 'el-GR',
+    name: 'Greek',
+    nativeName: 'Ελληνικά',
+    flag: '🇬🇷',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Eleni',
+      age: 35,
+      nationality: 'Greek',
+      description:
+        'a Greek tutor who loves teaching through Athens history, the Aegean islands, and Greek philosophy',
+    },
+    exampleTopics: ['Athens and the Acropolis', 'Greek islands like Santorini and Crete', 'Greek philosophy and mythology'],
+  },
+
+  gu: {
+    code: 'gu',
+    bcp47: 'gu-IN',
+    name: 'Gujarati',
+    nativeName: 'ગુજરાતી',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Priya',
+      age: 32,
+      nationality: 'Gujarati',
+      description:
+        'a Gujarati tutor passionate about Ahmedabad, vegetarian cuisine, and Garba dance',
+    },
+    exampleTopics: ['Ahmedabad and Gujarati culture', 'dhokla, thepla and vegetarian thalis', 'Navratri and Garba'],
+  },
+
+  he: {
+    code: 'he',
+    bcp47: 'he-IL',
+    name: 'Hebrew',
+    nativeName: 'עברית',
+    flag: '🇮🇱',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Noa',
+      age: 31,
+      nationality: 'Israeli',
+      description:
+        'an Israeli tutor who loves teaching Hebrew through Tel Aviv beach life, Jerusalem history, and modern Israeli culture',
+    },
+    exampleTopics: ['Tel Aviv and Jaffa', 'Jerusalem and the Old City', 'shakshuka and Israeli cuisine'],
+  },
+
+  hi: {
+    code: 'hi',
+    bcp47: 'hi-IN',
+    name: 'Hindi',
+    nativeName: 'हिन्दी',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Aarav',
+      age: 34,
+      nationality: 'Indian',
+      description:
+        'an Indian tutor who loves teaching Hindi through Bollywood, street food, and travel across India',
+    },
+    exampleTopics: ['Delhi and Mumbai life', 'Bollywood films and music', 'Indian street food and chai'],
+  },
+
+  hu: {
+    code: 'hu',
+    bcp47: 'hu-HU',
+    name: 'Hungarian',
+    nativeName: 'Magyar',
+    flag: '🇭🇺',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Zsófia',
+      age: 33,
+      nationality: 'Hungarian',
+      description:
+        'a Hungarian tutor passionate about Budapest, thermal baths, and Magyar literature',
+    },
+    exampleTopics: ['Budapest and the Danube', 'gulyás and Hungarian cuisine', 'thermal baths and ruin pubs'],
+  },
+
+  id: {
+    code: 'id',
+    bcp47: 'id-ID',
+    name: 'Indonesian',
+    nativeName: 'Indonesia',
+    flag: '🇮🇩',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Budi',
+      age: 35,
+      nationality: 'Indonesian',
+      description:
+        'an Indonesian tutor who loves teaching through Bali, Javanese culture, and the diverse archipelago',
+    },
+    exampleTopics: ['Bali and Java', 'nasi goreng and Indonesian street food', 'island hopping across Indonesia'],
+  },
+
+  ja: {
+    code: 'ja',
+    bcp47: 'ja-JP',
+    name: 'Japanese',
+    nativeName: '日本語',
+    flag: '🇯🇵',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Yuki',
+      age: 32,
+      nationality: 'Japanese',
+      description:
+        'a Japanese tutor who loves teaching through Tokyo neighborhoods, tea ceremony, and modern pop culture',
+    },
+    exampleTopics: ['Tokyo neighborhoods and Kyoto temples', 'sushi, ramen, and izakaya culture', 'anime, manga, and J-pop'],
+  },
+
+  kn: {
+    code: 'kn',
+    bcp47: 'kn-IN',
+    name: 'Kannada',
+    nativeName: 'ಕನ್ನಡ',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Kavya',
+      age: 30,
+      nationality: 'Kannadiga',
+      description:
+        'a Karnataka tutor passionate about Bengaluru, Mysuru palaces, and South Indian cuisine',
+    },
+    exampleTopics: ['Bengaluru tech and café culture', 'Mysuru palace and Hampi ruins', 'masala dosa and South Indian food'],
+  },
+
+  kk: {
+    code: 'kk',
+    bcp47: 'kk-KZ',
+    name: 'Kazakh',
+    nativeName: 'Қазақ',
+    flag: '🇰🇿',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Aigerim',
+      age: 32,
+      nationality: 'Kazakh',
+      description:
+        'a Kazakh tutor who loves teaching through Almaty, the steppes, and Central Asian traditions',
+    },
+    exampleTopics: ['Almaty and Astana', 'beshbarmak and steppe cuisine', 'eagle hunting and Kazakh traditions'],
+  },
+
+  ko: {
+    code: 'ko',
+    bcp47: 'ko-KR',
+    name: 'Korean',
+    nativeName: '한국어',
+    flag: '🇰🇷',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Min-jun',
+      age: 31,
+      nationality: 'Korean',
+      description:
+        'a Korean tutor who loves teaching through Seoul life, K-pop, and Korean food culture',
+    },
+    exampleTopics: ['Seoul neighborhoods and Jeju island', 'K-pop, K-dramas, and Korean cinema', 'kimchi, bibimbap, and Korean BBQ'],
+  },
+
+  lv: {
+    code: 'lv',
+    bcp47: 'lv-LV',
+    name: 'Latvian',
+    nativeName: 'Latviešu',
+    flag: '🇱🇻',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Liene',
+      age: 33,
+      nationality: 'Latvian',
+      description:
+        'a Latvian tutor passionate about Riga art nouveau, Baltic forests, and folk traditions',
+    },
+    exampleTopics: ['Riga old town and art nouveau', 'Latvian folk songs (dainas)', 'midsummer Jāņi celebrations'],
+  },
+
+  lt: {
+    code: 'lt',
+    bcp47: 'lt-LT',
+    name: 'Lithuanian',
+    nativeName: 'Lietuvių',
+    flag: '🇱🇹',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Tomas',
+      age: 35,
+      nationality: 'Lithuanian',
+      description:
+        'a Lithuanian tutor who loves Vilnius old town, Curonian Spit dunes, and Baltic history',
+    },
+    exampleTopics: ['Vilnius and Trakai castle', 'cepelinai and Lithuanian cuisine', 'Curonian Spit and the Baltic coast'],
+  },
+
+  mk: {
+    code: 'mk',
+    bcp47: 'mk-MK',
+    name: 'Macedonian',
+    nativeName: 'Македонски',
+    flag: '🇲🇰',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Nikola',
+      age: 36,
+      nationality: 'Macedonian',
+      description:
+        'a Macedonian tutor passionate about Skopje, Lake Ohrid, and Balkan history',
+    },
+    exampleTopics: ['Skopje and Lake Ohrid', 'tavče gravče and Macedonian cuisine', 'Balkan folk music'],
+  },
+
+  ms: {
+    code: 'ms',
+    bcp47: 'ms-MY',
+    name: 'Malay',
+    nativeName: 'Melayu',
+    flag: '🇲🇾',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Aisyah',
+      age: 32,
+      nationality: 'Malaysian',
+      description:
+        'a Malaysian tutor who loves teaching through KL street food, Penang heritage, and Borneo nature',
+    },
+    exampleTopics: ['Kuala Lumpur and Penang', 'nasi lemak and Malaysian street food', 'Borneo rainforests'],
+  },
+
+  ml: {
+    code: 'ml',
+    bcp47: 'ml-IN',
+    name: 'Malayalam',
+    nativeName: 'മലയാളം',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Anjali',
+      age: 31,
+      nationality: 'Malayali',
+      description:
+        'a Kerala tutor passionate about backwater houseboats, Kathakali, and Keralan cuisine',
+    },
+    exampleTopics: ['Kerala backwaters and Kochi', 'sadya and coconut-based cooking', 'Kathakali and traditional arts'],
+  },
+
+  mr: {
+    code: 'mr',
+    bcp47: 'mr-IN',
+    name: 'Marathi',
+    nativeName: 'मराठी',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Rohan',
+      age: 33,
+      nationality: 'Marathi',
+      description:
+        'a Maharashtrian tutor who loves teaching through Mumbai life, Pune culture, and Marathi cinema',
+    },
+    exampleTopics: ['Mumbai and the Western Ghats', 'vada pav and Maharashtrian street food', 'Marathi theatre and cinema'],
+  },
+
+  no: {
+    code: 'no',
+    bcp47: 'nb-NO',
+    name: 'Norwegian',
+    nativeName: 'Norsk',
+    flag: '🇳🇴',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Sigrid',
+      age: 32,
+      nationality: 'Norwegian',
+      description:
+        'a Norwegian tutor passionate about Oslo, fjord hikes, and Nordic outdoor life',
+    },
+    exampleTopics: ['Oslo and the Norwegian fjords', 'friluftsliv and outdoor culture', 'brunost and Norwegian cuisine'],
+  },
+
+  fa: {
+    code: 'fa',
+    bcp47: 'fa-IR',
+    name: 'Persian',
+    nativeName: 'فارسی',
+    flag: '🇮🇷',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Darius',
+      age: 36,
+      nationality: 'Iranian',
+      description:
+        'an Iranian tutor who loves teaching Persian through Tehran life, classical poetry, and Iranian cuisine',
+    },
+    exampleTopics: ['Tehran and Isfahan', 'Hafez, Rumi and Persian poetry', 'kebabs, stews, and Persian rice dishes'],
+  },
+
+  pl: {
+    code: 'pl',
+    bcp47: 'pl-PL',
+    name: 'Polish',
+    nativeName: 'Polski',
+    flag: '🇵🇱',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Kasia',
+      age: 33,
+      nationality: 'Polish',
+      description:
+        'a Polish tutor passionate about Kraków old town, Polish cinema, and pierogi traditions',
+    },
+    exampleTopics: ['Kraków and Warsaw', 'pierogi and Polish home cooking', 'Polish cinema and history'],
+  },
+
+  pa: {
+    code: 'pa',
+    bcp47: 'pa-IN',
+    name: 'Punjabi',
+    nativeName: 'ਪੰਜਾਬੀ',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Harpreet',
+      age: 34,
+      nationality: 'Punjabi',
+      description:
+        'a Punjabi tutor who loves teaching through Amritsar, bhangra, and Punjabi food culture',
+    },
+    exampleTopics: ['Amritsar and the Golden Temple', 'butter chicken, sarson da saag, and Punjabi food', 'bhangra and Punjabi music'],
+  },
+
+  ro: {
+    code: 'ro',
+    bcp47: 'ro-RO',
+    name: 'Romanian',
+    nativeName: 'Română',
+    flag: '🇷🇴',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Andrei',
+      age: 35,
+      nationality: 'Romanian',
+      description:
+        'a Romanian tutor passionate about Bucharest, Transylvanian castles, and Carpathian villages',
+    },
+    exampleTopics: ['Bucharest and Transylvania', 'sarmale and Romanian home cooking', 'Carpathian mountains and folklore'],
+  },
+
+  ru: {
+    code: 'ru',
+    bcp47: 'ru-RU',
+    name: 'Russian',
+    nativeName: 'Русский',
+    flag: '🇷🇺',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Anastasia',
+      age: 34,
+      nationality: 'Russian',
+      description:
+        'a Russian tutor who loves teaching through Moscow life, classical literature, and Russian cuisine',
+    },
+    exampleTopics: ['Moscow and St. Petersburg', 'Tolstoy, Dostoevsky and Russian literature', 'borscht, pelmeni and Russian food'],
+  },
+
+  sr: {
+    code: 'sr',
+    bcp47: 'sr-RS',
+    name: 'Serbian',
+    nativeName: 'Српски',
+    flag: '🇷🇸',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Miloš',
+      age: 36,
+      nationality: 'Serbian',
+      description:
+        'a Serbian tutor passionate about Belgrade nightlife, Balkan music, and Serbian traditions',
+    },
+    exampleTopics: ['Belgrade nightlife and Novi Sad', 'ćevapi, ajvar and Serbian food', 'Exit Festival and Balkan music'],
+  },
+
+  sk: {
+    code: 'sk',
+    bcp47: 'sk-SK',
+    name: 'Slovak',
+    nativeName: 'Slovenčina',
+    flag: '🇸🇰',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Zuzana',
+      age: 32,
+      nationality: 'Slovak',
+      description:
+        'a Slovak tutor who loves Bratislava, the Tatra mountains, and Slovak folk traditions',
+    },
+    exampleTopics: ['Bratislava and the High Tatras', 'bryndzové halušky and Slovak cuisine', 'wooden churches and folk music'],
+  },
+
+  sl: {
+    code: 'sl',
+    bcp47: 'sl-SI',
+    name: 'Slovenian',
+    nativeName: 'Slovenščina',
+    flag: '🇸🇮',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Maja',
+      age: 31,
+      nationality: 'Slovenian',
+      description:
+        'a Slovenian tutor passionate about Ljubljana, Lake Bled, and Julian Alps hiking',
+    },
+    exampleTopics: ['Ljubljana and Lake Bled', 'potica and Slovenian cuisine', 'Julian Alps and Postojna caves'],
+  },
+
+  sw: {
+    code: 'sw',
+    bcp47: 'sw-KE',
+    name: 'Swahili',
+    nativeName: 'Kiswahili',
+    flag: '🇰🇪',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Amani',
+      age: 33,
+      nationality: 'Kenyan',
+      description:
+        'a Kenyan tutor who loves teaching Swahili through Nairobi life, coastal Lamu, and East African culture',
+    },
+    exampleTopics: ['Nairobi and the Maasai Mara', 'ugali, nyama choma and East African food', 'Swahili coastal culture and Lamu'],
+  },
+
+  sv: {
+    code: 'sv',
+    bcp47: 'sv-SE',
+    name: 'Swedish',
+    nativeName: 'Svenska',
+    flag: '🇸🇪',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Erik',
+      age: 35,
+      nationality: 'Swedish',
+      description:
+        'a Swedish tutor passionate about Stockholm, fika culture, and the Swedish countryside',
+    },
+    exampleTopics: ['Stockholm archipelago', 'fika and Swedish coffee culture', 'midsummer and Swedish traditions'],
+  },
+
+  ta: {
+    code: 'ta',
+    bcp47: 'ta-IN',
+    name: 'Tamil',
+    nativeName: 'தமிழ்',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Karthik',
+      age: 34,
+      nationality: 'Tamil',
+      description:
+        'a Tamil tutor who loves teaching through Chennai life, Tamil cinema, and South Indian temples',
+    },
+    exampleTopics: ['Chennai and Madurai temples', 'idli, dosa and Tamil cuisine', 'Tamil cinema and Carnatic music'],
+  },
+
+  te: {
+    code: 'te',
+    bcp47: 'te-IN',
+    name: 'Telugu',
+    nativeName: 'తెలుగు',
+    flag: '🇮🇳',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Lakshmi',
+      age: 32,
+      nationality: 'Telugu',
+      description:
+        'a Telugu tutor passionate about Hyderabad, biryani, and Tollywood cinema',
+    },
+    exampleTopics: ['Hyderabad and the Charminar', 'Hyderabadi biryani and Andhra cuisine', 'Tollywood films and Telugu poetry'],
+  },
+
+  th: {
+    code: 'th',
+    bcp47: 'th-TH',
+    name: 'Thai',
+    nativeName: 'ไทย',
+    flag: '🇹🇭',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Siriporn',
+      age: 31,
+      nationality: 'Thai',
+      description:
+        'a Thai tutor who loves teaching through Bangkok markets, island life, and Thai food culture',
+    },
+    exampleTopics: ['Bangkok and Chiang Mai', 'pad thai, tom yum and Thai street food', 'Thai islands and beaches'],
+  },
+
+  tr: {
+    code: 'tr',
+    bcp47: 'tr-TR',
+    name: 'Turkish',
+    nativeName: 'Türkçe',
+    flag: '🇹🇷',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Emre',
+      age: 35,
+      nationality: 'Turkish',
+      description:
+        'a Turkish tutor passionate about Istanbul, Anatolian history, and Turkish cuisine',
+    },
+    exampleTopics: ['Istanbul and the Bosphorus', 'kebabs, mezes and Turkish breakfasts', 'Cappadocia and Turkish coast'],
+  },
+
+  uk: {
+    code: 'uk',
+    bcp47: 'uk-UA',
+    name: 'Ukrainian',
+    nativeName: 'Українська',
+    flag: '🇺🇦',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Olena',
+      age: 33,
+      nationality: 'Ukrainian',
+      description:
+        'a Ukrainian tutor who loves teaching through Kyiv, Lviv coffee houses, and Ukrainian folk traditions',
+    },
+    exampleTopics: ['Kyiv and Lviv', 'borscht, varenyky and Ukrainian cuisine', 'Ukrainian folk songs and embroidery'],
+  },
+
+  ur: {
+    code: 'ur',
+    bcp47: 'ur-PK',
+    name: 'Urdu',
+    nativeName: 'اردو',
+    flag: '🇵🇰',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Zara',
+      age: 32,
+      nationality: 'Pakistani',
+      description:
+        'a Pakistani tutor passionate about Lahore, Urdu poetry (ghazals), and Mughlai cuisine',
+    },
+    exampleTopics: ['Lahore and Karachi', 'Urdu ghazals and shayari', 'biryani, nihari and Mughlai food'],
+  },
+
+  vi: {
+    code: 'vi',
+    bcp47: 'vi-VN',
+    name: 'Vietnamese',
+    nativeName: 'Tiếng Việt',
+    flag: '🇻🇳',
+    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Linh',
+      age: 30,
+      nationality: 'Vietnamese',
+      description:
+        'a Vietnamese tutor who loves teaching through Hanoi street food, Hạ Long Bay, and Vietnamese coffee culture',
+    },
+    exampleTopics: ['Hanoi and Ho Chi Minh City', 'phở, bánh mì and Vietnamese street food', 'Hạ Long Bay and the Mekong Delta'],
+  },
+
+  cy: {
+    code: 'cy',
+    bcp47: 'cy-GB',
+    name: 'Welsh',
+    nativeName: 'Cymraeg',
+    flag: '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
+    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    teacherPersona: {
+      name: 'Rhys',
+      age: 36,
+      nationality: 'Welsh',
+      description:
+        'a Welsh tutor passionate about Cardiff, Snowdonia hiking, and Welsh poetry traditions',
+    },
+    exampleTopics: ['Cardiff and the Welsh valleys', 'Snowdonia and the coastal path', 'cawl, Welsh cakes and male voice choirs'],
   },
 };
 

--- a/backend/src/config/languages.ts
+++ b/backend/src/config/languages.ts
@@ -6,8 +6,9 @@
  * Wire-format conventions:
  * - `bcp47` is the canonical form ("es-ES", "fi-FI"). Used for TTS-2 via
  *   `session.providerData.tts.language` (and the REST `/tts/v1/voice` `language` field).
- * - `code` is ISO 639-1 ("es", "fi"). Used as the map key, dropdown value,
- *   and Soniox STT hint via `transcription.language`.
+ * - `code` is ISO 639-1 where available ("es", "fi"), otherwise ISO 639-2
+ *   ("fil"). Used as the map key, dropdown value, and Soniox STT hint via
+ *   `transcription.language`.
  *
  * To add a new language: add a new entry to SUPPORTED_LANGUAGES.
  */
@@ -31,7 +32,7 @@ export interface TTSConfig {
 }
 
 export interface LanguageConfig {
-  /** ISO 639-1 (e.g., 'es', 'ja', 'fr') — map key, dropdown value, Soniox STT hint. */
+  /** ISO 639-1 where available, otherwise ISO 639-2 (e.g. 'fil') — map key, dropdown value, Soniox STT hint. */
   code: string;
   /** BCP-47 with uppercase region (e.g., 'es-ES', 'fi-FI') — TTS-2 language hint. */
   bcp47: string;
@@ -309,7 +310,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Afrikaans',
     nativeName: 'Afrikaans',
     flag: '🇿🇦',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Pieter',
       age: 36,
@@ -317,7 +323,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a South African tutor who loves teaching Afrikaans through Cape Town life, braai culture, and Karoo road trips',
     },
-    exampleTopics: ['Cape Town and Table Mountain', 'braai culture and South African food', 'Afrikaans music and writers'],
+    exampleTopics: [
+      'Cape Town and Table Mountain',
+      'braai culture and South African food',
+      'Afrikaans music and writers',
+    ],
     disfluencies: ['ag', 'um', 'nou ja'],
   },
 
@@ -327,7 +337,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Albanian',
     nativeName: 'Shqip',
     flag: '🇦🇱',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Arta',
       age: 32,
@@ -335,7 +350,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Albanian tutor passionate about Tirana, the Albanian Riviera, and traditional cuisine',
     },
-    exampleTopics: ['Tirana street life', 'the Albanian Riviera and Ksamil', 'traditional dishes like tavë kosi'],
+    exampleTopics: [
+      'Tirana street life',
+      'the Albanian Riviera and Ksamil',
+      'traditional dishes like tavë kosi',
+    ],
     disfluencies: ['ëëë', 'pra', 'domethënë'],
   },
 
@@ -345,7 +364,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Arabic',
     nativeName: 'العربية',
     flag: '🇸🇦',
-    ttsConfig: { speakerId: 'Nour', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Nour',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Layla',
       age: 33,
@@ -353,7 +377,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Saudi tutor who loves teaching Arabic through Middle Eastern history, classical poetry, and modern culture',
     },
-    exampleTopics: ['Arabic poetry and proverbs', 'food across the Levant and Gulf', 'travel to Petra, Cairo, and Riyadh'],
+    exampleTopics: [
+      'Arabic poetry and proverbs',
+      'food across the Levant and Gulf',
+      'travel to Petra, Cairo, and Riyadh',
+    ],
     disfluencies: ['يعني', 'هه', 'يا عني'],
   },
 
@@ -363,7 +391,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Azerbaijani',
     nativeName: 'Azərbaycanca',
     flag: '🇦🇿',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Elmira',
       age: 34,
@@ -371,7 +404,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Azerbaijani tutor who loves Baku, the Caspian coast, and Caucasus cuisine',
     },
-    exampleTopics: ['Baku old city and modern skyline', 'plov and traditional Azerbaijani food', 'mugham music'],
+    exampleTopics: [
+      'Baku old city and modern skyline',
+      'plov and traditional Azerbaijani food',
+      'mugham music',
+    ],
     disfluencies: ['yəni', 'ee', 'belə'],
   },
 
@@ -380,8 +417,13 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     bcp47: 'eu-ES',
     name: 'Basque',
     nativeName: 'Euskara',
-    flag: '🏴',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    flag: '🟥',
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Iker',
       age: 35,
@@ -389,7 +431,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Basque tutor who loves teaching Euskara through San Sebastián pintxos and Bilbao culture',
     },
-    exampleTopics: ['pintxo bars in Donostia', 'the Guggenheim and Bilbao', 'Basque mythology and rural life'],
+    exampleTopics: [
+      'pintxo bars in Donostia',
+      'the Guggenheim and Bilbao',
+      'Basque mythology and rural life',
+    ],
     disfluencies: ['eee', 'beno', 'ba'],
   },
 
@@ -399,7 +445,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Belarusian',
     nativeName: 'Беларуская',
     flag: '🇧🇾',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Hanna',
       age: 31,
@@ -407,7 +458,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Belarusian tutor passionate about Minsk, traditional folk songs, and Belarusian literature',
     },
-    exampleTopics: ['Minsk and Belarusian cities', 'draniki and traditional cuisine', 'Belarusian folk music'],
+    exampleTopics: [
+      'Minsk and Belarusian cities',
+      'draniki and traditional cuisine',
+      'Belarusian folk music',
+    ],
     disfluencies: ['ну', 'эээ', 'значыць'],
   },
 
@@ -417,7 +472,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Bengali',
     nativeName: 'বাংলা',
     flag: '🇧🇩',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Anika',
       age: 30,
@@ -425,7 +485,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Bangladeshi tutor who loves teaching Bengali through Dhaka life, Tagore poetry, and the Sundarbans',
     },
-    exampleTopics: ['Dhaka street food', 'Tagore and Bengali literature', 'Sundarbans and rural Bengal'],
+    exampleTopics: [
+      'Dhaka street food',
+      'Tagore and Bengali literature',
+      'Sundarbans and rural Bengal',
+    ],
     disfluencies: ['মানে', 'ইয়ে', 'আচ্ছা'],
   },
 
@@ -435,7 +499,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Bosnian',
     nativeName: 'Bosanski',
     flag: '🇧🇦',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Edin',
       age: 37,
@@ -443,7 +512,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Bosnian tutor passionate about Sarajevo, ćevapi, and Balkan history',
     },
-    exampleTopics: ['Sarajevo old town', 'ćevapi and Bosnian cuisine', 'Mostar and the Stari Most bridge'],
+    exampleTopics: [
+      'Sarajevo old town',
+      'ćevapi and Bosnian cuisine',
+      'Mostar and the Stari Most bridge',
+    ],
     disfluencies: ['ovaj', 'ono', 'znaš'],
   },
 
@@ -453,7 +526,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Bulgarian',
     nativeName: 'Български',
     flag: '🇧🇬',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Boyana',
       age: 33,
@@ -461,7 +539,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Bulgarian tutor who loves Sofia, Rila monasteries, and Black Sea summers',
     },
-    exampleTopics: ['Sofia and the Vitosha mountains', 'banitsa and shopska salad', 'Bulgarian folk music and dance'],
+    exampleTopics: [
+      'Sofia and the Vitosha mountains',
+      'banitsa and shopska salad',
+      'Bulgarian folk music and dance',
+    ],
     disfluencies: ['ами', 'значи', 'нали'],
   },
 
@@ -470,8 +552,13 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     bcp47: 'ca-ES',
     name: 'Catalan',
     nativeName: 'Català',
-    flag: '🏴',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    flag: '🟨',
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Jordi',
       age: 36,
@@ -479,7 +566,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Catalan tutor who loves Barcelona, Gaudí, and Mediterranean coastal life',
     },
-    exampleTopics: ['Barcelona neighborhoods', 'castellers and Catalan traditions', 'pa amb tomàquet and Catalan food'],
+    exampleTopics: [
+      'Barcelona neighborhoods',
+      'castellers and Catalan traditions',
+      'pa amb tomàquet and Catalan food',
+    ],
     disfluencies: ['eh', 'doncs', 'o sigui'],
   },
 
@@ -489,7 +580,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Chinese',
     nativeName: '中文',
     flag: '🇨🇳',
-    ttsConfig: { speakerId: 'Mei', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Mei',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Mei',
       age: 32,
@@ -497,8 +593,21 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Beijing tutor who loves teaching Mandarin through tea culture, classical poetry, and modern Chinese cinema',
     },
-    exampleTopics: ['Beijing hutongs and street food', 'Chinese tea culture', 'classical poetry and modern films'],
-    disfluencies: ['那个', '就是', '嗯', '就', '其实', '你知道', '对', '怎么说呢'],
+    exampleTopics: [
+      'Beijing hutongs and street food',
+      'Chinese tea culture',
+      'classical poetry and modern films',
+    ],
+    disfluencies: [
+      '那个',
+      '就是',
+      '嗯',
+      '就',
+      '其实',
+      '你知道',
+      '对',
+      '怎么说呢',
+    ],
   },
 
   hr: {
@@ -507,7 +616,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Croatian',
     nativeName: 'Hrvatski',
     flag: '🇭🇷',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Ivana',
       age: 34,
@@ -515,7 +629,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Croatian tutor passionate about Dubrovnik, Dalmatian islands, and Adriatic seafood',
     },
-    exampleTopics: ['Dalmatian coast and islands', 'Plitvice Lakes', 'peka and Croatian seafood'],
+    exampleTopics: [
+      'Dalmatian coast and islands',
+      'Plitvice Lakes',
+      'peka and Croatian seafood',
+    ],
     disfluencies: ['ovaj', 'znaš', 'pa'],
   },
 
@@ -525,7 +643,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Czech',
     nativeName: 'Čeština',
     flag: '🇨🇿',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Pavel',
       age: 38,
@@ -533,7 +656,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Czech tutor who loves teaching through Prague history, Bohemian beer halls, and Czech literature',
     },
-    exampleTopics: ['Prague castle and the old town', 'Czech pivo and beer culture', 'Kafka and Czech cinema'],
+    exampleTopics: [
+      'Prague castle and the old town',
+      'Czech pivo and beer culture',
+      'Kafka and Czech cinema',
+    ],
     disfluencies: ['no', 'jakoby', 'prostě'],
   },
 
@@ -543,7 +670,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Danish',
     nativeName: 'Dansk',
     flag: '🇩🇰',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Mette',
       age: 33,
@@ -551,7 +683,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Danish tutor passionate about Copenhagen, hygge, and Nordic design',
     },
-    exampleTopics: ['Copenhagen and Nyhavn', 'hygge and Scandinavian design', 'smørrebrød and new Nordic cuisine'],
+    exampleTopics: [
+      'Copenhagen and Nyhavn',
+      'hygge and Scandinavian design',
+      'smørrebrød and new Nordic cuisine',
+    ],
     disfluencies: ['øh', 'altså', 'jo'],
   },
 
@@ -561,7 +697,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Dutch',
     nativeName: 'Nederlands',
     flag: '🇳🇱',
-    ttsConfig: { speakerId: 'Katrien', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Katrien',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Sanne',
       age: 31,
@@ -569,7 +710,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Dutch tutor who loves teaching through Amsterdam canals, cycling culture, and Dutch design',
     },
-    exampleTopics: ['Amsterdam canals and museums', 'cycling and Dutch daily life', 'stroopwafels and bitterballen'],
+    exampleTopics: [
+      'Amsterdam canals and museums',
+      'cycling and Dutch daily life',
+      'stroopwafels and bitterballen',
+    ],
     disfluencies: ['eh', 'nou', 'weet je'],
   },
 
@@ -579,7 +724,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Estonian',
     nativeName: 'Eesti',
     flag: '🇪🇪',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Kaarel',
       age: 34,
@@ -587,17 +737,26 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Estonian tutor passionate about Tallinn old town, e-Estonia, and Baltic forests',
     },
-    exampleTopics: ['Tallinn medieval old town', 'Estonian saunas and forest culture', 'e-Estonia and digital society'],
+    exampleTopics: [
+      'Tallinn medieval old town',
+      'Estonian saunas and forest culture',
+      'e-Estonia and digital society',
+    ],
     disfluencies: ['noh', 'eee', 'tähendab'],
   },
 
-  tl: {
-    code: 'tl',
+  fil: {
+    code: 'fil',
     bcp47: 'fil-PH',
     name: 'Filipino',
     nativeName: 'Filipino',
     flag: '🇵🇭',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Liza',
       age: 30,
@@ -605,7 +764,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Filipino tutor who loves teaching Tagalog through Manila life, island hopping, and family traditions',
     },
-    exampleTopics: ['Manila and Cebu', 'adobo and lechon', 'Philippine islands and beaches'],
+    exampleTopics: [
+      'Manila and Cebu',
+      'adobo and lechon',
+      'Philippine islands and beaches',
+    ],
     disfluencies: ['ano', 'kasi', 'parang'],
   },
 
@@ -615,7 +778,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Finnish',
     nativeName: 'Suomi',
     flag: '🇫🇮',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Aino',
       age: 33,
@@ -623,7 +791,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Finnish tutor who loves teaching Finnish through Helsinki life and Nordic culture',
     },
-    exampleTopics: ['sauna culture', 'Finnish design and architecture', 'life in Helsinki and Lapland'],
+    exampleTopics: [
+      'sauna culture',
+      'Finnish design and architecture',
+      'life in Helsinki and Lapland',
+    ],
     disfluencies: ['öö', 'niinku', 'tota'],
   },
 
@@ -632,8 +804,13 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     bcp47: 'gl-ES',
     name: 'Galician',
     nativeName: 'Galego',
-    flag: '🏴',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    flag: '🟦',
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Brais',
       age: 36,
@@ -641,7 +818,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Galician tutor passionate about Santiago de Compostela, Atlantic coast, and Galician seafood',
     },
-    exampleTopics: ['Camino de Santiago', 'pulpo a la gallega and seafood', 'Galician folk music'],
+    exampleTopics: [
+      'Camino de Santiago',
+      'pulpo a la gallega and seafood',
+      'Galician folk music',
+    ],
     disfluencies: ['eh', 'pois', 'ou sexa'],
   },
 
@@ -651,7 +832,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Greek',
     nativeName: 'Ελληνικά',
     flag: '🇬🇷',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Eleni',
       age: 35,
@@ -659,7 +845,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Greek tutor who loves teaching through Athens history, the Aegean islands, and Greek philosophy',
     },
-    exampleTopics: ['Athens and the Acropolis', 'Greek islands like Santorini and Crete', 'Greek philosophy and mythology'],
+    exampleTopics: [
+      'Athens and the Acropolis',
+      'Greek islands like Santorini and Crete',
+      'Greek philosophy and mythology',
+    ],
     disfluencies: ['ε', 'δηλαδή', 'ξέρεις'],
   },
 
@@ -669,7 +859,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Gujarati',
     nativeName: 'ગુજરાતી',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Priya',
       age: 32,
@@ -677,7 +872,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Gujarati tutor passionate about Ahmedabad, vegetarian cuisine, and Garba dance',
     },
-    exampleTopics: ['Ahmedabad and Gujarati culture', 'dhokla, thepla and vegetarian thalis', 'Navratri and Garba'],
+    exampleTopics: [
+      'Ahmedabad and Gujarati culture',
+      'dhokla, thepla and vegetarian thalis',
+      'Navratri and Garba',
+    ],
     disfluencies: ['એમ', 'મતલબ', 'જેમ કે'],
   },
 
@@ -687,7 +886,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Hebrew',
     nativeName: 'עברית',
     flag: '🇮🇱',
-    ttsConfig: { speakerId: 'Yael', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Yael',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Noa',
       age: 31,
@@ -695,7 +899,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Israeli tutor who loves teaching Hebrew through Tel Aviv beach life, Jerusalem history, and modern Israeli culture',
     },
-    exampleTopics: ['Tel Aviv and Jaffa', 'Jerusalem and the Old City', 'shakshuka and Israeli cuisine'],
+    exampleTopics: [
+      'Tel Aviv and Jaffa',
+      'Jerusalem and the Old City',
+      'shakshuka and Israeli cuisine',
+    ],
     disfluencies: ['אהה', 'יעני', 'כאילו'],
   },
 
@@ -705,7 +913,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Hindi',
     nativeName: 'हिन्दी',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Aarav', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Aarav',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Aarav',
       age: 34,
@@ -713,7 +926,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Indian tutor who loves teaching Hindi through Bollywood, street food, and travel across India',
     },
-    exampleTopics: ['Delhi and Mumbai life', 'Bollywood films and music', 'Indian street food and chai'],
+    exampleTopics: [
+      'Delhi and Mumbai life',
+      'Bollywood films and music',
+      'Indian street food and chai',
+    ],
     disfluencies: ['मतलब', 'अरे', 'यानी'],
   },
 
@@ -723,7 +940,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Hungarian',
     nativeName: 'Magyar',
     flag: '🇭🇺',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Zsófia',
       age: 33,
@@ -731,7 +953,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Hungarian tutor passionate about Budapest, thermal baths, and Magyar literature',
     },
-    exampleTopics: ['Budapest and the Danube', 'gulyás and Hungarian cuisine', 'thermal baths and ruin pubs'],
+    exampleTopics: [
+      'Budapest and the Danube',
+      'gulyás and Hungarian cuisine',
+      'thermal baths and ruin pubs',
+    ],
     disfluencies: ['hát', 'izé', 'ugye'],
   },
 
@@ -739,9 +965,14 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     code: 'id',
     bcp47: 'id-ID',
     name: 'Indonesian',
-    nativeName: 'Indonesia',
+    nativeName: 'Bahasa Indonesia',
     flag: '🇮🇩',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Budi',
       age: 35,
@@ -749,7 +980,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Indonesian tutor who loves teaching through Bali, Javanese culture, and the diverse archipelago',
     },
-    exampleTopics: ['Bali and Java', 'nasi goreng and Indonesian street food', 'island hopping across Indonesia'],
+    exampleTopics: [
+      'Bali and Java',
+      'nasi goreng and Indonesian street food',
+      'island hopping across Indonesia',
+    ],
     disfluencies: ['anu', 'gitu', 'ya'],
   },
 
@@ -759,7 +994,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Japanese',
     nativeName: '日本語',
     flag: '🇯🇵',
-    ttsConfig: { speakerId: 'Hina', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Hina',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Yuki',
       age: 32,
@@ -767,8 +1007,21 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Japanese tutor who loves teaching through Tokyo neighborhoods, tea ceremony, and modern pop culture',
     },
-    exampleTopics: ['Tokyo neighborhoods and Kyoto temples', 'sushi, ramen, and izakaya culture', 'anime, manga, and J-pop'],
-    disfluencies: ['えーと', 'あの', 'そうですね', 'うーん', 'まあ', 'なんか', 'ええ', 'まあね'],
+    exampleTopics: [
+      'Tokyo neighborhoods and Kyoto temples',
+      'sushi, ramen, and izakaya culture',
+      'anime, manga, and J-pop',
+    ],
+    disfluencies: [
+      'えーと',
+      'あの',
+      'そうですね',
+      'うーん',
+      'まあ',
+      'なんか',
+      'ええ',
+      'まあね',
+    ],
   },
 
   kn: {
@@ -777,7 +1030,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Kannada',
     nativeName: 'ಕನ್ನಡ',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Kavya',
       age: 30,
@@ -785,7 +1043,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Karnataka tutor passionate about Bengaluru, Mysuru palaces, and South Indian cuisine',
     },
-    exampleTopics: ['Bengaluru tech and café culture', 'Mysuru palace and Hampi ruins', 'masala dosa and South Indian food'],
+    exampleTopics: [
+      'Bengaluru tech and café culture',
+      'Mysuru palace and Hampi ruins',
+      'masala dosa and South Indian food',
+    ],
     disfluencies: ['ಅಂದ್ರೆ', 'ಅಯ್ಯೋ', 'ಹಾ'],
   },
 
@@ -795,7 +1057,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Kazakh',
     nativeName: 'Қазақ',
     flag: '🇰🇿',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Aigerim',
       age: 32,
@@ -803,7 +1070,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Kazakh tutor who loves teaching through Almaty, the steppes, and Central Asian traditions',
     },
-    exampleTopics: ['Almaty and Astana', 'beshbarmak and steppe cuisine', 'eagle hunting and Kazakh traditions'],
+    exampleTopics: [
+      'Almaty and Astana',
+      'beshbarmak and steppe cuisine',
+      'eagle hunting and Kazakh traditions',
+    ],
     disfluencies: ['яғни', 'ееее', 'былай'],
   },
 
@@ -813,7 +1084,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Korean',
     nativeName: '한국어',
     flag: '🇰🇷',
-    ttsConfig: { speakerId: 'Hyunwoo', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Hyunwoo',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Min-jun',
       age: 31,
@@ -821,8 +1097,21 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Korean tutor who loves teaching through Seoul life, K-pop, and Korean food culture',
     },
-    exampleTopics: ['Seoul neighborhoods and Jeju island', 'K-pop, K-dramas, and Korean cinema', 'kimchi, bibimbap, and Korean BBQ'],
-    disfluencies: ['그…', '음…', '저기', '뭐', '있잖아', '그러니까', '아', '말하자면'],
+    exampleTopics: [
+      'Seoul neighborhoods and Jeju island',
+      'K-pop, K-dramas, and Korean cinema',
+      'kimchi, bibimbap, and Korean BBQ',
+    ],
+    disfluencies: [
+      '그…',
+      '음…',
+      '저기',
+      '뭐',
+      '있잖아',
+      '그러니까',
+      '아',
+      '말하자면',
+    ],
   },
 
   lv: {
@@ -831,7 +1120,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Latvian',
     nativeName: 'Latviešu',
     flag: '🇱🇻',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Liene',
       age: 33,
@@ -839,7 +1133,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Latvian tutor passionate about Riga art nouveau, Baltic forests, and folk traditions',
     },
-    exampleTopics: ['Riga old town and art nouveau', 'Latvian folk songs (dainas)', 'midsummer Jāņi celebrations'],
+    exampleTopics: [
+      'Riga old town and art nouveau',
+      'Latvian folk songs (dainas)',
+      'midsummer Jāņi celebrations',
+    ],
     disfluencies: ['nu', 'tātad', 'redzi'],
   },
 
@@ -849,7 +1147,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Lithuanian',
     nativeName: 'Lietuvių',
     flag: '🇱🇹',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Tomas',
       age: 35,
@@ -857,7 +1160,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Lithuanian tutor who loves Vilnius old town, Curonian Spit dunes, and Baltic history',
     },
-    exampleTopics: ['Vilnius and Trakai castle', 'cepelinai and Lithuanian cuisine', 'Curonian Spit and the Baltic coast'],
+    exampleTopics: [
+      'Vilnius and Trakai castle',
+      'cepelinai and Lithuanian cuisine',
+      'Curonian Spit and the Baltic coast',
+    ],
     disfluencies: ['na', 'tai', 'žinai'],
   },
 
@@ -867,7 +1174,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Macedonian',
     nativeName: 'Македонски',
     flag: '🇲🇰',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Nikola',
       age: 36,
@@ -875,7 +1187,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Macedonian tutor passionate about Skopje, Lake Ohrid, and Balkan history',
     },
-    exampleTopics: ['Skopje and Lake Ohrid', 'tavče gravče and Macedonian cuisine', 'Balkan folk music'],
+    exampleTopics: [
+      'Skopje and Lake Ohrid',
+      'tavče gravče and Macedonian cuisine',
+      'Balkan folk music',
+    ],
     disfluencies: ['па', 'значи', 'знаеш'],
   },
 
@@ -885,7 +1201,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Malay',
     nativeName: 'Melayu',
     flag: '🇲🇾',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Aisyah',
       age: 32,
@@ -893,7 +1214,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Malaysian tutor who loves teaching through KL street food, Penang heritage, and Borneo nature',
     },
-    exampleTopics: ['Kuala Lumpur and Penang', 'nasi lemak and Malaysian street food', 'Borneo rainforests'],
+    exampleTopics: [
+      'Kuala Lumpur and Penang',
+      'nasi lemak and Malaysian street food',
+      'Borneo rainforests',
+    ],
     disfluencies: ['hmm', 'macam', 'tu'],
   },
 
@@ -903,7 +1228,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Malayalam',
     nativeName: 'മലയാളം',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Anjali',
       age: 31,
@@ -911,7 +1241,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Kerala tutor passionate about backwater houseboats, Kathakali, and Keralan cuisine',
     },
-    exampleTopics: ['Kerala backwaters and Kochi', 'sadya and coconut-based cooking', 'Kathakali and traditional arts'],
+    exampleTopics: [
+      'Kerala backwaters and Kochi',
+      'sadya and coconut-based cooking',
+      'Kathakali and traditional arts',
+    ],
     disfluencies: ['അതേ', 'പിന്നെ', 'അല്ലെ'],
   },
 
@@ -921,7 +1255,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Marathi',
     nativeName: 'मराठी',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Rohan',
       age: 33,
@@ -929,7 +1268,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Maharashtrian tutor who loves teaching through Mumbai life, Pune culture, and Marathi cinema',
     },
-    exampleTopics: ['Mumbai and the Western Ghats', 'vada pav and Maharashtrian street food', 'Marathi theatre and cinema'],
+    exampleTopics: [
+      'Mumbai and the Western Ghats',
+      'vada pav and Maharashtrian street food',
+      'Marathi theatre and cinema',
+    ],
     disfluencies: ['म्हणजे', 'अरे', 'तर'],
   },
 
@@ -939,7 +1282,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Norwegian',
     nativeName: 'Norsk',
     flag: '🇳🇴',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Sigrid',
       age: 32,
@@ -947,7 +1295,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Norwegian tutor passionate about Oslo, fjord hikes, and Nordic outdoor life',
     },
-    exampleTopics: ['Oslo and the Norwegian fjords', 'friluftsliv and outdoor culture', 'brunost and Norwegian cuisine'],
+    exampleTopics: [
+      'Oslo and the Norwegian fjords',
+      'friluftsliv and outdoor culture',
+      'brunost and Norwegian cuisine',
+    ],
     disfluencies: ['eh', 'liksom', 'altså'],
   },
 
@@ -957,7 +1309,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Persian',
     nativeName: 'فارسی',
     flag: '🇮🇷',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Darius',
       age: 36,
@@ -965,7 +1322,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'an Iranian tutor who loves teaching Persian through Tehran life, classical poetry, and Iranian cuisine',
     },
-    exampleTopics: ['Tehran and Isfahan', 'Hafez, Rumi and Persian poetry', 'kebabs, stews, and Persian rice dishes'],
+    exampleTopics: [
+      'Tehran and Isfahan',
+      'Hafez, Rumi and Persian poetry',
+      'kebabs, stews, and Persian rice dishes',
+    ],
     disfluencies: ['یعنی', 'خب', 'چیز'],
   },
 
@@ -975,7 +1336,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Polish',
     nativeName: 'Polski',
     flag: '🇵🇱',
-    ttsConfig: { speakerId: 'Szymon', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Szymon',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Szymon',
       age: 33,
@@ -983,7 +1349,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Polish tutor passionate about Kraków old town, Polish cinema, and pierogi traditions',
     },
-    exampleTopics: ['Kraków and Warsaw', 'pierogi and Polish home cooking', 'Polish cinema and history'],
+    exampleTopics: [
+      'Kraków and Warsaw',
+      'pierogi and Polish home cooking',
+      'Polish cinema and history',
+    ],
     disfluencies: ['no', 'yyy', 'wiesz'],
   },
 
@@ -993,7 +1363,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Punjabi',
     nativeName: 'ਪੰਜਾਬੀ',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Harpreet',
       age: 34,
@@ -1001,7 +1376,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Punjabi tutor who loves teaching through Amritsar, bhangra, and Punjabi food culture',
     },
-    exampleTopics: ['Amritsar and the Golden Temple', 'butter chicken, sarson da saag, and Punjabi food', 'bhangra and Punjabi music'],
+    exampleTopics: [
+      'Amritsar and the Golden Temple',
+      'butter chicken, sarson da saag, and Punjabi food',
+      'bhangra and Punjabi music',
+    ],
     disfluencies: ['ਮਤਲਬ', 'ਯਾਨੀ', 'ਉਹ'],
   },
 
@@ -1011,7 +1390,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Romanian',
     nativeName: 'Română',
     flag: '🇷🇴',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Andrei',
       age: 35,
@@ -1019,7 +1403,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Romanian tutor passionate about Bucharest, Transylvanian castles, and Carpathian villages',
     },
-    exampleTopics: ['Bucharest and Transylvania', 'sarmale and Romanian home cooking', 'Carpathian mountains and folklore'],
+    exampleTopics: [
+      'Bucharest and Transylvania',
+      'sarmale and Romanian home cooking',
+      'Carpathian mountains and folklore',
+    ],
     disfluencies: ['adică', 'păi', 'deci'],
   },
 
@@ -1029,7 +1417,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Russian',
     nativeName: 'Русский',
     flag: '🇷🇺',
-    ttsConfig: { speakerId: 'Elena', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Elena',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Anastasia',
       age: 34,
@@ -1037,7 +1430,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Russian tutor who loves teaching through Moscow life, classical literature, and Russian cuisine',
     },
-    exampleTopics: ['Moscow and St. Petersburg', 'Tolstoy, Dostoevsky and Russian literature', 'borscht, pelmeni and Russian food'],
+    exampleTopics: [
+      'Moscow and St. Petersburg',
+      'Tolstoy, Dostoevsky and Russian literature',
+      'borscht, pelmeni and Russian food',
+    ],
     disfluencies: ['ну', 'это', 'как бы'],
   },
 
@@ -1047,7 +1444,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Serbian',
     nativeName: 'Српски',
     flag: '🇷🇸',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Miloš',
       age: 36,
@@ -1055,7 +1457,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Serbian tutor passionate about Belgrade nightlife, Balkan music, and Serbian traditions',
     },
-    exampleTopics: ['Belgrade nightlife and Novi Sad', 'ćevapi, ajvar and Serbian food', 'Exit Festival and Balkan music'],
+    exampleTopics: [
+      'Belgrade nightlife and Novi Sad',
+      'ćevapi, ajvar and Serbian food',
+      'Exit Festival and Balkan music',
+    ],
     disfluencies: ['ovaj', 'znaš', 'pa'],
   },
 
@@ -1065,7 +1471,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Slovak',
     nativeName: 'Slovenčina',
     flag: '🇸🇰',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Zuzana',
       age: 32,
@@ -1073,7 +1484,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Slovak tutor who loves Bratislava, the Tatra mountains, and Slovak folk traditions',
     },
-    exampleTopics: ['Bratislava and the High Tatras', 'bryndzové halušky and Slovak cuisine', 'wooden churches and folk music'],
+    exampleTopics: [
+      'Bratislava and the High Tatras',
+      'bryndzové halušky and Slovak cuisine',
+      'wooden churches and folk music',
+    ],
     disfluencies: ['no', 'akože', 'proste'],
   },
 
@@ -1083,7 +1498,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Slovenian',
     nativeName: 'Slovenščina',
     flag: '🇸🇮',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Maja',
       age: 31,
@@ -1091,7 +1511,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Slovenian tutor passionate about Ljubljana, Lake Bled, and Julian Alps hiking',
     },
-    exampleTopics: ['Ljubljana and Lake Bled', 'potica and Slovenian cuisine', 'Julian Alps and Postojna caves'],
+    exampleTopics: [
+      'Ljubljana and Lake Bled',
+      'potica and Slovenian cuisine',
+      'Julian Alps and Postojna caves',
+    ],
     disfluencies: ['no', 'pač', 'a veš'],
   },
 
@@ -1101,7 +1525,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Swahili',
     nativeName: 'Kiswahili',
     flag: '🇰🇪',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Amani',
       age: 33,
@@ -1109,7 +1538,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Kenyan tutor who loves teaching Swahili through Nairobi life, coastal Lamu, and East African culture',
     },
-    exampleTopics: ['Nairobi and the Maasai Mara', 'ugali, nyama choma and East African food', 'Swahili coastal culture and Lamu'],
+    exampleTopics: [
+      'Nairobi and the Maasai Mara',
+      'ugali, nyama choma and East African food',
+      'Swahili coastal culture and Lamu',
+    ],
     disfluencies: ['eee', 'yaani', 'basi'],
   },
 
@@ -1119,7 +1552,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Swedish',
     nativeName: 'Svenska',
     flag: '🇸🇪',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Erik',
       age: 35,
@@ -1127,7 +1565,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Swedish tutor passionate about Stockholm, fika culture, and the Swedish countryside',
     },
-    exampleTopics: ['Stockholm archipelago', 'fika and Swedish coffee culture', 'midsummer and Swedish traditions'],
+    exampleTopics: [
+      'Stockholm archipelago',
+      'fika and Swedish coffee culture',
+      'midsummer and Swedish traditions',
+    ],
     disfluencies: ['öh', 'liksom', 'alltså'],
   },
 
@@ -1137,7 +1579,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Tamil',
     nativeName: 'தமிழ்',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Karthik',
       age: 34,
@@ -1145,7 +1592,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Tamil tutor who loves teaching through Chennai life, Tamil cinema, and South Indian temples',
     },
-    exampleTopics: ['Chennai and Madurai temples', 'idli, dosa and Tamil cuisine', 'Tamil cinema and Carnatic music'],
+    exampleTopics: [
+      'Chennai and Madurai temples',
+      'idli, dosa and Tamil cuisine',
+      'Tamil cinema and Carnatic music',
+    ],
     disfluencies: ['அதான்', 'அப்பா', 'என்ன'],
   },
 
@@ -1155,7 +1606,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Telugu',
     nativeName: 'తెలుగు',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Lakshmi',
       age: 32,
@@ -1163,7 +1619,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Telugu tutor passionate about Hyderabad, biryani, and Tollywood cinema',
     },
-    exampleTopics: ['Hyderabad and the Charminar', 'Hyderabadi biryani and Andhra cuisine', 'Tollywood films and Telugu poetry'],
+    exampleTopics: [
+      'Hyderabad and the Charminar',
+      'Hyderabadi biryani and Andhra cuisine',
+      'Tollywood films and Telugu poetry',
+    ],
     disfluencies: ['అంటే', 'అదే', 'అరె'],
   },
 
@@ -1173,7 +1633,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Thai',
     nativeName: 'ไทย',
     flag: '🇹🇭',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Siriporn',
       age: 31,
@@ -1181,7 +1646,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Thai tutor who loves teaching through Bangkok markets, island life, and Thai food culture',
     },
-    exampleTopics: ['Bangkok and Chiang Mai', 'pad thai, tom yum and Thai street food', 'Thai islands and beaches'],
+    exampleTopics: [
+      'Bangkok and Chiang Mai',
+      'pad thai, tom yum and Thai street food',
+      'Thai islands and beaches',
+    ],
     disfluencies: ['เอ่อ', 'แบบ', 'คือ'],
   },
 
@@ -1191,7 +1660,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Turkish',
     nativeName: 'Türkçe',
     flag: '🇹🇷',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Emre',
       age: 35,
@@ -1199,7 +1673,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Turkish tutor passionate about Istanbul, Anatolian history, and Turkish cuisine',
     },
-    exampleTopics: ['Istanbul and the Bosphorus', 'kebabs, mezes and Turkish breakfasts', 'Cappadocia and Turkish coast'],
+    exampleTopics: [
+      'Istanbul and the Bosphorus',
+      'kebabs, mezes and Turkish breakfasts',
+      'Cappadocia and Turkish coast',
+    ],
     disfluencies: ['şey', 'yani', 'işte'],
   },
 
@@ -1209,7 +1687,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Ukrainian',
     nativeName: 'Українська',
     flag: '🇺🇦',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Olena',
       age: 33,
@@ -1217,7 +1700,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Ukrainian tutor who loves teaching through Kyiv, Lviv coffee houses, and Ukrainian folk traditions',
     },
-    exampleTopics: ['Kyiv and Lviv', 'borscht, varenyky and Ukrainian cuisine', 'Ukrainian folk songs and embroidery'],
+    exampleTopics: [
+      'Kyiv and Lviv',
+      'borscht, varenyky and Ukrainian cuisine',
+      'Ukrainian folk songs and embroidery',
+    ],
     disfluencies: ['ну', 'це', 'тобто'],
   },
 
@@ -1227,7 +1714,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Urdu',
     nativeName: 'اردو',
     flag: '🇵🇰',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Zara',
       age: 32,
@@ -1235,7 +1727,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Pakistani tutor passionate about Lahore, Urdu poetry (ghazals), and Mughlai cuisine',
     },
-    exampleTopics: ['Lahore and Karachi', 'Urdu ghazals and shayari', 'biryani, nihari and Mughlai food'],
+    exampleTopics: [
+      'Lahore and Karachi',
+      'Urdu ghazals and shayari',
+      'biryani, nihari and Mughlai food',
+    ],
     disfluencies: ['یعنی', 'مطلب', 'وہ'],
   },
 
@@ -1245,7 +1741,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Vietnamese',
     nativeName: 'Tiếng Việt',
     flag: '🇻🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Sarah',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Linh',
       age: 30,
@@ -1253,7 +1754,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Vietnamese tutor who loves teaching through Hanoi street food, Hạ Long Bay, and Vietnamese coffee culture',
     },
-    exampleTopics: ['Hanoi and Ho Chi Minh City', 'phở, bánh mì and Vietnamese street food', 'Hạ Long Bay and the Mekong Delta'],
+    exampleTopics: [
+      'Hanoi and Ho Chi Minh City',
+      'phở, bánh mì and Vietnamese street food',
+      'Hạ Long Bay and the Mekong Delta',
+    ],
     disfluencies: ['ờ', 'thì', 'cái'],
   },
 
@@ -1263,7 +1768,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Welsh',
     nativeName: 'Cymraeg',
     flag: '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: {
+      speakerId: 'Jason',
+      modelId: 'inworld-tts-2',
+      speakingRate: 1,
+      temperature: 1,
+    },
     teacherPersona: {
       name: 'Rhys',
       age: 36,
@@ -1271,7 +1781,11 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       description:
         'a Welsh tutor passionate about Cardiff, Snowdonia hiking, and Welsh poetry traditions',
     },
-    exampleTopics: ['Cardiff and the Welsh valleys', 'Snowdonia and the coastal path', 'cawl, Welsh cakes and male voice choirs'],
+    exampleTopics: [
+      'Cardiff and the Welsh valleys',
+      'Snowdonia and the coastal path',
+      'cawl, Welsh cakes and male voice choirs',
+    ],
     disfluencies: ['ym', 'wel', "ti'n gwybod"],
   },
 };

--- a/backend/src/config/languages.ts
+++ b/backend/src/config/languages.ts
@@ -82,7 +82,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'American idioms and slang',
       'travel across the United States',
     ],
-    disfluencies: ['um', 'uh', 'well', 'you know'],
+    disfluencies: [
+      'um',
+      'uh',
+      'well',
+      'you know',
+      'like',
+      'I mean',
+      'so',
+      'hmm',
+      'kinda',
+      'right',
+    ],
   },
 
   es: {
@@ -111,7 +122,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'the concept of brunch across cultures',
       'Balkan travel',
     ],
-    disfluencies: ['este', 'eh', 'pues', 'o sea'],
+    disfluencies: [
+      'este',
+      'eh',
+      'pues',
+      'o sea',
+      'bueno',
+      'a ver',
+      'mira',
+      'vale',
+      'digamos',
+      'es que',
+    ],
   },
 
   fr: {
@@ -141,7 +163,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'travel in Provence and the French Riviera',
       'French music from Édith Piaf to modern artists',
     ],
-    disfluencies: ['euh', 'ben', 'bah', 'tu vois'],
+    disfluencies: [
+      'euh',
+      'ben',
+      'bah',
+      'tu vois',
+      'eh bien',
+      'enfin',
+      'quoi',
+      'voilà',
+      'disons',
+      'en fait',
+    ],
   },
 
   de: {
@@ -171,7 +204,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'traveling through Bavaria and the Alps',
       'German literature from Goethe to modern authors',
     ],
-    disfluencies: ['ähm', 'also', 'naja', 'sozusagen'],
+    disfluencies: [
+      'ähm',
+      'also',
+      'naja',
+      'sozusagen',
+      'tja',
+      'hmm',
+      'eben',
+      'halt',
+      'irgendwie',
+      'weißt du',
+    ],
   },
 
   it: {
@@ -201,7 +245,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'fashion and design in Milan',
       'Italian music from opera to modern pop',
     ],
-    disfluencies: ['ehm', 'cioè', 'allora', 'insomma'],
+    disfluencies: [
+      'ehm',
+      'cioè',
+      'allora',
+      'insomma',
+      'beh',
+      'ecco',
+      'diciamo',
+      'tipo',
+      'magari',
+      'praticamente',
+    ],
   },
 
   pt: {
@@ -231,7 +286,18 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'football (soccer) culture',
       'the Amazon and Brazilian nature',
     ],
-    disfluencies: ['é', 'tipo', 'então', 'sabe'],
+    disfluencies: [
+      'é',
+      'tipo',
+      'então',
+      'sabe',
+      'né',
+      'olha',
+      'pois é',
+      'meio que',
+      'tipo assim',
+      'cara',
+    ],
   },
 
   // ── Soniox-supported languages (alphabetical) ────────────────────────
@@ -432,7 +498,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Beijing tutor who loves teaching Mandarin through tea culture, classical poetry, and modern Chinese cinema',
     },
     exampleTopics: ['Beijing hutongs and street food', 'Chinese tea culture', 'classical poetry and modern films'],
-    disfluencies: ['那个', '就是', '嗯'],
+    disfluencies: ['那个', '就是', '嗯', '就', '其实', '你知道', '对', '怎么说呢'],
   },
 
   hr: {
@@ -702,7 +768,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Japanese tutor who loves teaching through Tokyo neighborhoods, tea ceremony, and modern pop culture',
     },
     exampleTopics: ['Tokyo neighborhoods and Kyoto temples', 'sushi, ramen, and izakaya culture', 'anime, manga, and J-pop'],
-    disfluencies: ['えーと', 'あの', 'そうですね'],
+    disfluencies: ['えーと', 'あの', 'そうですね', 'うーん', 'まあ', 'なんか', 'ええ', 'まあね'],
   },
 
   kn: {
@@ -756,7 +822,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Korean tutor who loves teaching through Seoul life, K-pop, and Korean food culture',
     },
     exampleTopics: ['Seoul neighborhoods and Jeju island', 'K-pop, K-dramas, and Korean cinema', 'kimchi, bibimbap, and Korean BBQ'],
-    disfluencies: ['그…', '음…', '저기'],
+    disfluencies: ['그…', '음…', '저기', '뭐', '있잖아', '그러니까', '아', '말하자면'],
   },
 
   lv: {

--- a/backend/src/config/languages.ts
+++ b/backend/src/config/languages.ts
@@ -43,13 +43,16 @@ export interface LanguageConfig {
   ttsConfig: TTSConfig;
   teacherPersona: TeacherPersona;
   exampleTopics: string[];
+  /** 2–4 natural disfluency fillers in the target language, spoken inline (e.g. ja: ['えーと', 'あの']). */
+  disfluencies: string[];
 }
 
 /**
  * Supported Languages Configuration
  *
- * The first 6 entries are curated personas (existing). All other languages
- * use Sarah/Jason TTS-2 voices alternated, with concise templated personas.
+ * The first 6 entries are curated personas. Among the rest, languages
+ * with native voices in the Inworld TTS-2 catalog use them; the others
+ * fall back to the multilingual Sarah/Jason voices.
  */
 export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
   // ── Curated languages ────────────────────────────────────────
@@ -79,6 +82,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'American idioms and slang',
       'travel across the United States',
     ],
+    disfluencies: ['um', 'uh', 'well', 'you know'],
   },
 
   es: {
@@ -107,6 +111,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'the concept of brunch across cultures',
       'Balkan travel',
     ],
+    disfluencies: ['este', 'eh', 'pues', 'o sea'],
   },
 
   fr: {
@@ -136,6 +141,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'travel in Provence and the French Riviera',
       'French music from Édith Piaf to modern artists',
     ],
+    disfluencies: ['euh', 'ben', 'bah', 'tu vois'],
   },
 
   de: {
@@ -165,6 +171,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'traveling through Bavaria and the Alps',
       'German literature from Goethe to modern authors',
     ],
+    disfluencies: ['ähm', 'also', 'naja', 'sozusagen'],
   },
 
   it: {
@@ -194,6 +201,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'fashion and design in Milan',
       'Italian music from opera to modern pop',
     ],
+    disfluencies: ['ehm', 'cioè', 'allora', 'insomma'],
   },
 
   pt: {
@@ -223,9 +231,12 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
       'football (soccer) culture',
       'the Amazon and Brazilian nature',
     ],
+    disfluencies: ['é', 'tipo', 'então', 'sabe'],
   },
 
-  // ── Soniox-supported languages (alphabetical, alternating Sarah/Jason) ─
+  // ── Soniox-supported languages (alphabetical) ────────────────────────
+  // Languages with native voices in the Inworld catalog use them; the rest
+  // alternate Sarah/Jason as multilingual TTS-2 fallbacks.
   af: {
     code: 'af',
     bcp47: 'af-ZA',
@@ -241,6 +252,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a South African tutor who loves teaching Afrikaans through Cape Town life, braai culture, and Karoo road trips',
     },
     exampleTopics: ['Cape Town and Table Mountain', 'braai culture and South African food', 'Afrikaans music and writers'],
+    disfluencies: ['ag', 'um', 'nou ja'],
   },
 
   sq: {
@@ -258,6 +270,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Albanian tutor passionate about Tirana, the Albanian Riviera, and traditional cuisine',
     },
     exampleTopics: ['Tirana street life', 'the Albanian Riviera and Ksamil', 'traditional dishes like tavë kosi'],
+    disfluencies: ['ëëë', 'pra', 'domethënë'],
   },
 
   ar: {
@@ -266,7 +279,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Arabic',
     nativeName: 'العربية',
     flag: '🇸🇦',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Nour', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Layla',
       age: 33,
@@ -275,6 +288,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Saudi tutor who loves teaching Arabic through Middle Eastern history, classical poetry, and modern culture',
     },
     exampleTopics: ['Arabic poetry and proverbs', 'food across the Levant and Gulf', 'travel to Petra, Cairo, and Riyadh'],
+    disfluencies: ['يعني', 'هه', 'يا عني'],
   },
 
   az: {
@@ -292,6 +306,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Azerbaijani tutor who loves Baku, the Caspian coast, and Caucasus cuisine',
     },
     exampleTopics: ['Baku old city and modern skyline', 'plov and traditional Azerbaijani food', 'mugham music'],
+    disfluencies: ['yəni', 'ee', 'belə'],
   },
 
   eu: {
@@ -309,6 +324,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Basque tutor who loves teaching Euskara through San Sebastián pintxos and Bilbao culture',
     },
     exampleTopics: ['pintxo bars in Donostia', 'the Guggenheim and Bilbao', 'Basque mythology and rural life'],
+    disfluencies: ['eee', 'beno', 'ba'],
   },
 
   be: {
@@ -326,6 +342,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Belarusian tutor passionate about Minsk, traditional folk songs, and Belarusian literature',
     },
     exampleTopics: ['Minsk and Belarusian cities', 'draniki and traditional cuisine', 'Belarusian folk music'],
+    disfluencies: ['ну', 'эээ', 'значыць'],
   },
 
   bn: {
@@ -343,6 +360,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Bangladeshi tutor who loves teaching Bengali through Dhaka life, Tagore poetry, and the Sundarbans',
     },
     exampleTopics: ['Dhaka street food', 'Tagore and Bengali literature', 'Sundarbans and rural Bengal'],
+    disfluencies: ['মানে', 'ইয়ে', 'আচ্ছা'],
   },
 
   bs: {
@@ -360,6 +378,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Bosnian tutor passionate about Sarajevo, ćevapi, and Balkan history',
     },
     exampleTopics: ['Sarajevo old town', 'ćevapi and Bosnian cuisine', 'Mostar and the Stari Most bridge'],
+    disfluencies: ['ovaj', 'ono', 'znaš'],
   },
 
   bg: {
@@ -377,6 +396,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Bulgarian tutor who loves Sofia, Rila monasteries, and Black Sea summers',
     },
     exampleTopics: ['Sofia and the Vitosha mountains', 'banitsa and shopska salad', 'Bulgarian folk music and dance'],
+    disfluencies: ['ами', 'значи', 'нали'],
   },
 
   ca: {
@@ -394,6 +414,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Catalan tutor who loves Barcelona, Gaudí, and Mediterranean coastal life',
     },
     exampleTopics: ['Barcelona neighborhoods', 'castellers and Catalan traditions', 'pa amb tomàquet and Catalan food'],
+    disfluencies: ['eh', 'doncs', 'o sigui'],
   },
 
   zh: {
@@ -402,7 +423,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Chinese',
     nativeName: '中文',
     flag: '🇨🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Mei', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Mei',
       age: 32,
@@ -411,6 +432,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Beijing tutor who loves teaching Mandarin through tea culture, classical poetry, and modern Chinese cinema',
     },
     exampleTopics: ['Beijing hutongs and street food', 'Chinese tea culture', 'classical poetry and modern films'],
+    disfluencies: ['那个', '就是', '嗯'],
   },
 
   hr: {
@@ -428,6 +450,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Croatian tutor passionate about Dubrovnik, Dalmatian islands, and Adriatic seafood',
     },
     exampleTopics: ['Dalmatian coast and islands', 'Plitvice Lakes', 'peka and Croatian seafood'],
+    disfluencies: ['ovaj', 'znaš', 'pa'],
   },
 
   cs: {
@@ -445,6 +468,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Czech tutor who loves teaching through Prague history, Bohemian beer halls, and Czech literature',
     },
     exampleTopics: ['Prague castle and the old town', 'Czech pivo and beer culture', 'Kafka and Czech cinema'],
+    disfluencies: ['no', 'jakoby', 'prostě'],
   },
 
   da: {
@@ -462,6 +486,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Danish tutor passionate about Copenhagen, hygge, and Nordic design',
     },
     exampleTopics: ['Copenhagen and Nyhavn', 'hygge and Scandinavian design', 'smørrebrød and new Nordic cuisine'],
+    disfluencies: ['øh', 'altså', 'jo'],
   },
 
   nl: {
@@ -470,7 +495,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Dutch',
     nativeName: 'Nederlands',
     flag: '🇳🇱',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Katrien', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Sanne',
       age: 31,
@@ -479,6 +504,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Dutch tutor who loves teaching through Amsterdam canals, cycling culture, and Dutch design',
     },
     exampleTopics: ['Amsterdam canals and museums', 'cycling and Dutch daily life', 'stroopwafels and bitterballen'],
+    disfluencies: ['eh', 'nou', 'weet je'],
   },
 
   et: {
@@ -496,6 +522,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Estonian tutor passionate about Tallinn old town, e-Estonia, and Baltic forests',
     },
     exampleTopics: ['Tallinn medieval old town', 'Estonian saunas and forest culture', 'e-Estonia and digital society'],
+    disfluencies: ['noh', 'eee', 'tähendab'],
   },
 
   tl: {
@@ -513,6 +540,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Filipino tutor who loves teaching Tagalog through Manila life, island hopping, and family traditions',
     },
     exampleTopics: ['Manila and Cebu', 'adobo and lechon', 'Philippine islands and beaches'],
+    disfluencies: ['ano', 'kasi', 'parang'],
   },
 
   fi: {
@@ -530,6 +558,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Finnish tutor who loves teaching Finnish through Helsinki life and Nordic culture',
     },
     exampleTopics: ['sauna culture', 'Finnish design and architecture', 'life in Helsinki and Lapland'],
+    disfluencies: ['öö', 'niinku', 'tota'],
   },
 
   gl: {
@@ -547,6 +576,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Galician tutor passionate about Santiago de Compostela, Atlantic coast, and Galician seafood',
     },
     exampleTopics: ['Camino de Santiago', 'pulpo a la gallega and seafood', 'Galician folk music'],
+    disfluencies: ['eh', 'pois', 'ou sexa'],
   },
 
   el: {
@@ -564,6 +594,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Greek tutor who loves teaching through Athens history, the Aegean islands, and Greek philosophy',
     },
     exampleTopics: ['Athens and the Acropolis', 'Greek islands like Santorini and Crete', 'Greek philosophy and mythology'],
+    disfluencies: ['ε', 'δηλαδή', 'ξέρεις'],
   },
 
   gu: {
@@ -581,6 +612,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Gujarati tutor passionate about Ahmedabad, vegetarian cuisine, and Garba dance',
     },
     exampleTopics: ['Ahmedabad and Gujarati culture', 'dhokla, thepla and vegetarian thalis', 'Navratri and Garba'],
+    disfluencies: ['એમ', 'મતલબ', 'જેમ કે'],
   },
 
   he: {
@@ -589,7 +621,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Hebrew',
     nativeName: 'עברית',
     flag: '🇮🇱',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Yael', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Noa',
       age: 31,
@@ -598,6 +630,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Israeli tutor who loves teaching Hebrew through Tel Aviv beach life, Jerusalem history, and modern Israeli culture',
     },
     exampleTopics: ['Tel Aviv and Jaffa', 'Jerusalem and the Old City', 'shakshuka and Israeli cuisine'],
+    disfluencies: ['אהה', 'יעני', 'כאילו'],
   },
 
   hi: {
@@ -606,7 +639,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Hindi',
     nativeName: 'हिन्दी',
     flag: '🇮🇳',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Aarav', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Aarav',
       age: 34,
@@ -615,6 +648,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Indian tutor who loves teaching Hindi through Bollywood, street food, and travel across India',
     },
     exampleTopics: ['Delhi and Mumbai life', 'Bollywood films and music', 'Indian street food and chai'],
+    disfluencies: ['मतलब', 'अरे', 'यानी'],
   },
 
   hu: {
@@ -632,6 +666,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Hungarian tutor passionate about Budapest, thermal baths, and Magyar literature',
     },
     exampleTopics: ['Budapest and the Danube', 'gulyás and Hungarian cuisine', 'thermal baths and ruin pubs'],
+    disfluencies: ['hát', 'izé', 'ugye'],
   },
 
   id: {
@@ -649,6 +684,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Indonesian tutor who loves teaching through Bali, Javanese culture, and the diverse archipelago',
     },
     exampleTopics: ['Bali and Java', 'nasi goreng and Indonesian street food', 'island hopping across Indonesia'],
+    disfluencies: ['anu', 'gitu', 'ya'],
   },
 
   ja: {
@@ -657,7 +693,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Japanese',
     nativeName: '日本語',
     flag: '🇯🇵',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Hina', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Yuki',
       age: 32,
@@ -666,6 +702,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Japanese tutor who loves teaching through Tokyo neighborhoods, tea ceremony, and modern pop culture',
     },
     exampleTopics: ['Tokyo neighborhoods and Kyoto temples', 'sushi, ramen, and izakaya culture', 'anime, manga, and J-pop'],
+    disfluencies: ['えーと', 'あの', 'そうですね'],
   },
 
   kn: {
@@ -683,6 +720,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Karnataka tutor passionate about Bengaluru, Mysuru palaces, and South Indian cuisine',
     },
     exampleTopics: ['Bengaluru tech and café culture', 'Mysuru palace and Hampi ruins', 'masala dosa and South Indian food'],
+    disfluencies: ['ಅಂದ್ರೆ', 'ಅಯ್ಯೋ', 'ಹಾ'],
   },
 
   kk: {
@@ -700,6 +738,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Kazakh tutor who loves teaching through Almaty, the steppes, and Central Asian traditions',
     },
     exampleTopics: ['Almaty and Astana', 'beshbarmak and steppe cuisine', 'eagle hunting and Kazakh traditions'],
+    disfluencies: ['яғни', 'ееее', 'былай'],
   },
 
   ko: {
@@ -708,7 +747,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Korean',
     nativeName: '한국어',
     flag: '🇰🇷',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Hyunwoo', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Min-jun',
       age: 31,
@@ -717,6 +756,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Korean tutor who loves teaching through Seoul life, K-pop, and Korean food culture',
     },
     exampleTopics: ['Seoul neighborhoods and Jeju island', 'K-pop, K-dramas, and Korean cinema', 'kimchi, bibimbap, and Korean BBQ'],
+    disfluencies: ['그…', '음…', '저기'],
   },
 
   lv: {
@@ -734,6 +774,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Latvian tutor passionate about Riga art nouveau, Baltic forests, and folk traditions',
     },
     exampleTopics: ['Riga old town and art nouveau', 'Latvian folk songs (dainas)', 'midsummer Jāņi celebrations'],
+    disfluencies: ['nu', 'tātad', 'redzi'],
   },
 
   lt: {
@@ -751,6 +792,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Lithuanian tutor who loves Vilnius old town, Curonian Spit dunes, and Baltic history',
     },
     exampleTopics: ['Vilnius and Trakai castle', 'cepelinai and Lithuanian cuisine', 'Curonian Spit and the Baltic coast'],
+    disfluencies: ['na', 'tai', 'žinai'],
   },
 
   mk: {
@@ -768,6 +810,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Macedonian tutor passionate about Skopje, Lake Ohrid, and Balkan history',
     },
     exampleTopics: ['Skopje and Lake Ohrid', 'tavče gravče and Macedonian cuisine', 'Balkan folk music'],
+    disfluencies: ['па', 'значи', 'знаеш'],
   },
 
   ms: {
@@ -785,6 +828,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Malaysian tutor who loves teaching through KL street food, Penang heritage, and Borneo nature',
     },
     exampleTopics: ['Kuala Lumpur and Penang', 'nasi lemak and Malaysian street food', 'Borneo rainforests'],
+    disfluencies: ['hmm', 'macam', 'tu'],
   },
 
   ml: {
@@ -802,6 +846,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Kerala tutor passionate about backwater houseboats, Kathakali, and Keralan cuisine',
     },
     exampleTopics: ['Kerala backwaters and Kochi', 'sadya and coconut-based cooking', 'Kathakali and traditional arts'],
+    disfluencies: ['അതേ', 'പിന്നെ', 'അല്ലെ'],
   },
 
   mr: {
@@ -819,6 +864,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Maharashtrian tutor who loves teaching through Mumbai life, Pune culture, and Marathi cinema',
     },
     exampleTopics: ['Mumbai and the Western Ghats', 'vada pav and Maharashtrian street food', 'Marathi theatre and cinema'],
+    disfluencies: ['म्हणजे', 'अरे', 'तर'],
   },
 
   no: {
@@ -836,6 +882,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Norwegian tutor passionate about Oslo, fjord hikes, and Nordic outdoor life',
     },
     exampleTopics: ['Oslo and the Norwegian fjords', 'friluftsliv and outdoor culture', 'brunost and Norwegian cuisine'],
+    disfluencies: ['eh', 'liksom', 'altså'],
   },
 
   fa: {
@@ -853,6 +900,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'an Iranian tutor who loves teaching Persian through Tehran life, classical poetry, and Iranian cuisine',
     },
     exampleTopics: ['Tehran and Isfahan', 'Hafez, Rumi and Persian poetry', 'kebabs, stews, and Persian rice dishes'],
+    disfluencies: ['یعنی', 'خب', 'چیز'],
   },
 
   pl: {
@@ -861,15 +909,16 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Polish',
     nativeName: 'Polski',
     flag: '🇵🇱',
-    ttsConfig: { speakerId: 'Jason', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Szymon', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
-      name: 'Kasia',
+      name: 'Szymon',
       age: 33,
       nationality: 'Polish',
       description:
         'a Polish tutor passionate about Kraków old town, Polish cinema, and pierogi traditions',
     },
     exampleTopics: ['Kraków and Warsaw', 'pierogi and Polish home cooking', 'Polish cinema and history'],
+    disfluencies: ['no', 'yyy', 'wiesz'],
   },
 
   pa: {
@@ -887,6 +936,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Punjabi tutor who loves teaching through Amritsar, bhangra, and Punjabi food culture',
     },
     exampleTopics: ['Amritsar and the Golden Temple', 'butter chicken, sarson da saag, and Punjabi food', 'bhangra and Punjabi music'],
+    disfluencies: ['ਮਤਲਬ', 'ਯਾਨੀ', 'ਉਹ'],
   },
 
   ro: {
@@ -904,6 +954,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Romanian tutor passionate about Bucharest, Transylvanian castles, and Carpathian villages',
     },
     exampleTopics: ['Bucharest and Transylvania', 'sarmale and Romanian home cooking', 'Carpathian mountains and folklore'],
+    disfluencies: ['adică', 'păi', 'deci'],
   },
 
   ru: {
@@ -912,7 +963,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
     name: 'Russian',
     nativeName: 'Русский',
     flag: '🇷🇺',
-    ttsConfig: { speakerId: 'Sarah', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
+    ttsConfig: { speakerId: 'Elena', modelId: 'inworld-tts-2', speakingRate: 1, temperature: 1 },
     teacherPersona: {
       name: 'Anastasia',
       age: 34,
@@ -921,6 +972,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Russian tutor who loves teaching through Moscow life, classical literature, and Russian cuisine',
     },
     exampleTopics: ['Moscow and St. Petersburg', 'Tolstoy, Dostoevsky and Russian literature', 'borscht, pelmeni and Russian food'],
+    disfluencies: ['ну', 'это', 'как бы'],
   },
 
   sr: {
@@ -938,6 +990,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Serbian tutor passionate about Belgrade nightlife, Balkan music, and Serbian traditions',
     },
     exampleTopics: ['Belgrade nightlife and Novi Sad', 'ćevapi, ajvar and Serbian food', 'Exit Festival and Balkan music'],
+    disfluencies: ['ovaj', 'znaš', 'pa'],
   },
 
   sk: {
@@ -955,6 +1008,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Slovak tutor who loves Bratislava, the Tatra mountains, and Slovak folk traditions',
     },
     exampleTopics: ['Bratislava and the High Tatras', 'bryndzové halušky and Slovak cuisine', 'wooden churches and folk music'],
+    disfluencies: ['no', 'akože', 'proste'],
   },
 
   sl: {
@@ -972,6 +1026,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Slovenian tutor passionate about Ljubljana, Lake Bled, and Julian Alps hiking',
     },
     exampleTopics: ['Ljubljana and Lake Bled', 'potica and Slovenian cuisine', 'Julian Alps and Postojna caves'],
+    disfluencies: ['no', 'pač', 'a veš'],
   },
 
   sw: {
@@ -989,6 +1044,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Kenyan tutor who loves teaching Swahili through Nairobi life, coastal Lamu, and East African culture',
     },
     exampleTopics: ['Nairobi and the Maasai Mara', 'ugali, nyama choma and East African food', 'Swahili coastal culture and Lamu'],
+    disfluencies: ['eee', 'yaani', 'basi'],
   },
 
   sv: {
@@ -1006,6 +1062,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Swedish tutor passionate about Stockholm, fika culture, and the Swedish countryside',
     },
     exampleTopics: ['Stockholm archipelago', 'fika and Swedish coffee culture', 'midsummer and Swedish traditions'],
+    disfluencies: ['öh', 'liksom', 'alltså'],
   },
 
   ta: {
@@ -1023,6 +1080,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Tamil tutor who loves teaching through Chennai life, Tamil cinema, and South Indian temples',
     },
     exampleTopics: ['Chennai and Madurai temples', 'idli, dosa and Tamil cuisine', 'Tamil cinema and Carnatic music'],
+    disfluencies: ['அதான்', 'அப்பா', 'என்ன'],
   },
 
   te: {
@@ -1040,6 +1098,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Telugu tutor passionate about Hyderabad, biryani, and Tollywood cinema',
     },
     exampleTopics: ['Hyderabad and the Charminar', 'Hyderabadi biryani and Andhra cuisine', 'Tollywood films and Telugu poetry'],
+    disfluencies: ['అంటే', 'అదే', 'అరె'],
   },
 
   th: {
@@ -1057,6 +1116,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Thai tutor who loves teaching through Bangkok markets, island life, and Thai food culture',
     },
     exampleTopics: ['Bangkok and Chiang Mai', 'pad thai, tom yum and Thai street food', 'Thai islands and beaches'],
+    disfluencies: ['เอ่อ', 'แบบ', 'คือ'],
   },
 
   tr: {
@@ -1074,6 +1134,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Turkish tutor passionate about Istanbul, Anatolian history, and Turkish cuisine',
     },
     exampleTopics: ['Istanbul and the Bosphorus', 'kebabs, mezes and Turkish breakfasts', 'Cappadocia and Turkish coast'],
+    disfluencies: ['şey', 'yani', 'işte'],
   },
 
   uk: {
@@ -1091,6 +1152,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Ukrainian tutor who loves teaching through Kyiv, Lviv coffee houses, and Ukrainian folk traditions',
     },
     exampleTopics: ['Kyiv and Lviv', 'borscht, varenyky and Ukrainian cuisine', 'Ukrainian folk songs and embroidery'],
+    disfluencies: ['ну', 'це', 'тобто'],
   },
 
   ur: {
@@ -1108,6 +1170,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Pakistani tutor passionate about Lahore, Urdu poetry (ghazals), and Mughlai cuisine',
     },
     exampleTopics: ['Lahore and Karachi', 'Urdu ghazals and shayari', 'biryani, nihari and Mughlai food'],
+    disfluencies: ['یعنی', 'مطلب', 'وہ'],
   },
 
   vi: {
@@ -1125,6 +1188,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Vietnamese tutor who loves teaching through Hanoi street food, Hạ Long Bay, and Vietnamese coffee culture',
     },
     exampleTopics: ['Hanoi and Ho Chi Minh City', 'phở, bánh mì and Vietnamese street food', 'Hạ Long Bay and the Mekong Delta'],
+    disfluencies: ['ờ', 'thì', 'cái'],
   },
 
   cy: {
@@ -1142,6 +1206,7 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageConfig> = {
         'a Welsh tutor passionate about Cardiff, Snowdonia hiking, and Welsh poetry traditions',
     },
     exampleTopics: ['Cardiff and the Welsh valleys', 'Snowdonia and the coastal path', 'cawl, Welsh cakes and male voice choirs'],
+    disfluencies: ['ym', 'wel', "ti'n gwybod"],
   },
 };
 

--- a/backend/src/config/server.ts
+++ b/backend/src/config/server.ts
@@ -18,5 +18,5 @@ export const serverConfig = {
     'wss://api.inworld.ai/api/v1/realtime/session',
 
   /** TTS voice model */
-  ttsModel: process.env.TTS_MODEL || 'inworld-tts-1.5-max',
+  ttsModel: process.env.TTS_MODEL || 'inworld-tts-2',
 } as const;

--- a/backend/src/helpers/tts-audio-generator.ts
+++ b/backend/src/helpers/tts-audio-generator.ts
@@ -82,7 +82,8 @@ async function generateTTSAudio(
     body: JSON.stringify({
       text: text.trim(),
       voice_id: voiceId,
-      model_id: 'inworld-tts-1.5-max',
+      model_id: 'inworld-tts-2',
+      language: langConfig.bcp47,
       audio_config: {
         audio_encoding: 'LINEAR16',
         sample_rate_hertz: 24000,

--- a/backend/src/helpers/tts-audio-generator.ts
+++ b/backend/src/helpers/tts-audio-generator.ts
@@ -71,7 +71,7 @@ async function generateTTSAudio(
   }
 
   const langConfig = getLanguageConfig(languageCode);
-  const voiceId = langConfig.ttsConfig.speakerId;
+  const { speakerId, modelId } = langConfig.ttsConfig;
 
   const response = await fetch(TTS_URL, {
     method: 'POST',
@@ -81,8 +81,8 @@ async function generateTTSAudio(
     },
     body: JSON.stringify({
       text: text.trim(),
-      voice_id: voiceId,
-      model_id: 'inworld-tts-2',
+      voice_id: speakerId,
+      model_id: modelId,
       language: langConfig.bcp47,
       audio_config: {
         audio_encoding: 'LINEAR16',

--- a/backend/src/services/inworld-llm.ts
+++ b/backend/src/services/inworld-llm.ts
@@ -188,7 +188,7 @@ Text: ${text}`;
           Authorization: `Basic ${this.apiKey}`,
         },
         body: JSON.stringify({
-          model: 'openai/gpt-4.1-nano',
+          model: 'openai/gpt-5.4-mini',
           messages: [{ role: 'user', content: prompt }],
           max_tokens: maxTokens,
           temperature,

--- a/backend/src/services/inworld-llm.ts
+++ b/backend/src/services/inworld-llm.ts
@@ -129,7 +129,11 @@ Text: ${text}`;
    * Pronounce text using Inworld TTS API.
    * Returns base64-encoded LINEAR16 audio at 24kHz, or null on failure.
    */
-  async pronounce(text: string, voiceId: string): Promise<string | null> {
+  async pronounce(
+    text: string,
+    voiceId: string,
+    bcp47: string
+  ): Promise<string | null> {
     if (!this.apiKey) return null;
 
     try {
@@ -142,7 +146,8 @@ Text: ${text}`;
         body: JSON.stringify({
           text,
           voice_id: voiceId,
-          model_id: 'inworld-tts-1.5-max',
+          model_id: 'inworld-tts-2',
+          language: bcp47,
           audio_config: {
             audio_encoding: 'LINEAR16',
             sample_rate_hertz: 24000,

--- a/backend/src/services/inworld-llm.ts
+++ b/backend/src/services/inworld-llm.ts
@@ -132,7 +132,8 @@ Text: ${text}`;
   async pronounce(
     text: string,
     voiceId: string,
-    bcp47: string
+    bcp47: string,
+    modelId: string
   ): Promise<string | null> {
     if (!this.apiKey) return null;
 
@@ -146,7 +147,7 @@ Text: ${text}`;
         body: JSON.stringify({
           text,
           voice_id: voiceId,
-          model_id: 'inworld-tts-2',
+          model_id: modelId,
           language: bcp47,
           audio_config: {
             audio_encoding: 'LINEAR16',

--- a/backend/src/services/memory-service.ts
+++ b/backend/src/services/memory-service.ts
@@ -257,7 +257,7 @@ Rules:
           Authorization: `Basic ${process.env.INWORLD_API_KEY}`,
         },
         body: JSON.stringify({
-          model: 'openai/gpt-4.1-nano',
+          model: 'openai/gpt-5.4-mini',
           messages: [{ role: 'user', content: prompt }],
           max_tokens: 200,
           temperature: 0.7,

--- a/backend/src/services/session-manager.ts
+++ b/backend/src/services/session-manager.ts
@@ -411,7 +411,7 @@ export class SessionManager {
     this.inworldSend({
       type: 'session.update',
       session: {
-        model: 'openai/gpt-4.1-nano',
+        model: 'openai/gpt-5.4-mini',
         instructions,
         output_modalities: ['audio', 'text'],
         audio: {

--- a/backend/src/services/session-manager.ts
+++ b/backend/src/services/session-manager.ts
@@ -399,10 +399,10 @@ export class SessionManager {
 - Ask open-ended questions to get them practicing ${name}
 
 # Voice & expressivity (TTS-2)
-- You may start a turn with ONE English steering tag in brackets, e.g. [speak conversationally], [speak warmly], [speak with light curiosity]. Always English, verb-led, optional.
-- Occasionally (zero or one per turn) include an English non-verbal tag inline: [laugh], [sigh], [clear throat], [gasp], [yawn]. Use only when genuinely warranted — never as decoration.
-- For natural hesitation, use disfluencies in ${name} INLINE (no brackets). Examples: ${disfluencies.join(', ')}. Use 0–2 per turn, only when thinking, never on emphatic statements.
-- Steering and non-verbal tags stay English even though you speak ${name} — they are voice directions, not spoken text. The disfluencies above ARE spoken aloud, so they MUST match ${name}.`;
+- Sound like a real person thinking out loud: include 1–2 natural ${name} disfluencies in MOST responses. Use ones like: ${disfluencies.join(', ')}. They are plain inline text (no brackets) and ARE spoken aloud. They work especially well to open a turn or pivot mid-sentence — e.g. "${disfluencies[0]}, …" or "…, ${disfluencies[Math.min(1, disfluencies.length - 1)]}, …". Don't force them onto emphatic or excited lines.
+- Optionally start a turn with ONE English steering tag in brackets, e.g. [speak conversationally], [speak warmly], [speak with light curiosity]. These direct your voice but are NOT spoken aloud.
+- Rarely (at most one per turn), inline an English non-verbal tag like [laugh], [sigh], [clear throat], [gasp], [yawn] — only when genuinely warranted.
+- Bracketed tags are always English voice directions and are silent. Disfluencies are ${name} text and ARE spoken — never bracket them.`;
 
     if (memoryContext) {
       instructions += `\n\n# Recent Conversation Context\n${memoryContext}`;

--- a/backend/src/services/session-manager.ts
+++ b/backend/src/services/session-manager.ts
@@ -236,10 +236,11 @@ export class SessionManager {
         break;
 
       case 'conversation.item.input_audio_transcription.delta': {
-        // Deltas are INCREMENTAL — accumulate into buffer (matches Inworld playground)
+        // Soniox emits CUMULATIVE deltas — each delta is the full transcript
+        // so far, not just new tokens. Replace the buffer rather than appending.
         const partialDelta = event.delta as string;
         if (partialDelta) {
-          this.userTextBuffer += partialDelta;
+          this.userTextBuffer = partialDelta;
           this.wsSend({
             type: 'partial_transcript',
             text: this.userTextBuffer,
@@ -348,7 +349,7 @@ export class SessionManager {
   }
 
   private sendSessionUpdate(): void {
-    const { teacherPersona, name, exampleTopics, ttsConfig, sttLanguageCode } =
+    const { teacherPersona, name, exampleTopics, ttsConfig, code, bcp47 } =
       this.langConfig;
     const memoryContext = this.memory.getContext();
 
@@ -381,8 +382,8 @@ export class SessionManager {
         audio: {
           input: {
             transcription: {
-              model: 'assemblyai/u3-rt-pro',
-              language: sttLanguageCode,
+              model: 'soniox/stt-rt-v4',
+              language: code,
             },
             turn_detection: {
               type: 'semantic_vad',
@@ -396,6 +397,9 @@ export class SessionManager {
             model: ttsConfig.modelId,
             speed: ttsConfig.speakingRate,
           },
+        },
+        providerData: {
+          tts: { language: bcp47 },
         },
       },
     });

--- a/backend/src/services/session-manager.ts
+++ b/backend/src/services/session-manager.ts
@@ -399,7 +399,9 @@ export class SessionManager {
 - Ask open-ended questions to get them practicing ${name}
 
 # Voice & expressivity (TTS-2)
-- Sound like a real person thinking out loud: include 1–2 natural ${name} disfluencies in MOST responses. Use ones like: ${disfluencies.join(', ')}. They are plain inline text (no brackets) and ARE spoken aloud. They work especially well to open a turn or pivot mid-sentence — e.g. "${disfluencies[0]}, …" or "…, ${disfluencies[Math.min(1, disfluencies.length - 1)]}, …". Don't force them onto emphatic or excited lines.
+- Sound like a real person thinking out loud: include 1–2 natural ${name} disfluencies in MOST responses. Examples for ${name} include ${disfluencies.join(', ')} — these are seeds, NOT an exhaustive list. Any common ${name} filler/hesitation word (or short hedging phrase) is welcome too.
+- VARY which disfluency you use. Never reuse the same one in consecutive responses, and don't lean on the single most generic one every turn — rotate across the natural range. Repeating "um" turn after turn sounds robotic.
+- Disfluencies are plain inline ${name} text (no brackets) and ARE spoken aloud. They work well to open a turn or pivot between clauses. Don't force them onto emphatic, excited, or one-word responses.
 - Optionally start a turn with ONE English steering tag in brackets, e.g. [speak conversationally], [speak warmly], [speak with light curiosity]. These direct your voice but are NOT spoken aloud.
 - Rarely (at most one per turn), inline an English non-verbal tag like [laugh], [sigh], [clear throat], [gasp], [yawn] — only when genuinely warranted.
 - Bracketed tags are always English voice directions and are silent. Disfluencies are ${name} text and ARE spoken — never bracket them.`;

--- a/backend/src/services/session-manager.ts
+++ b/backend/src/services/session-manager.ts
@@ -23,6 +23,19 @@ export interface SessionManagerOptions {
   languageCode: string;
 }
 
+/**
+ * Remove TTS-2 control tags from text the user will see/persist:
+ * steering tags ([speak ...]) and non-verbal tags ([laugh], [sigh], ...).
+ * Disfluencies are plain inline text and are not bracketed, so they survive.
+ */
+export function stripBracketedTags(text: string): string {
+  return text
+    .replace(/\[[^\][]*\]/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/ ([,.!?;:])/g, '$1')
+    .trim();
+}
+
 export class SessionManager {
   private ws: ClientWebSocket;
   private inworldWs: WebSocket | null = null;
@@ -37,6 +50,8 @@ export class SessionManager {
   private greetingItemId: string | null = null;
   /** Buffer for accumulating partial transcription deltas (incremental) */
   private userTextBuffer = '';
+  /** Held-back tail of an in-flight assistant chunk that may be the start of a `[...]` tag */
+  private assistantPendingTail = '';
 
   constructor(opts: SessionManagerOptions) {
     this.ws = opts.ws;
@@ -223,6 +238,7 @@ export class SessionManager {
       case 'input_audio_buffer.speech_started':
         // Cancel any in-progress agent response (matches Inworld playground)
         this.inworldSend({ type: 'response.cancel' });
+        this.assistantPendingTail = '';
         this.wsSend({ type: 'speech_detected', data: {} });
         this.wsSend({ type: 'interrupt', reason: 'speech_start' });
         break;
@@ -269,11 +285,14 @@ export class SessionManager {
       case 'response.output_audio_transcript.delta': {
         const delta = event.delta as string;
         if (delta) {
-          this.wsSend({
-            type: 'llm_response_chunk',
-            text: delta,
-            timestamp: Date.now(),
-          });
+          const cleanedDelta = this.consumeAssistantDelta(delta);
+          if (cleanedDelta) {
+            this.wsSend({
+              type: 'llm_response_chunk',
+              text: cleanedDelta,
+              timestamp: Date.now(),
+            });
+          }
         }
         break;
       }
@@ -293,11 +312,14 @@ export class SessionManager {
 
       case 'response.output_audio_transcript.done': {
         const transcript = event.transcript as string;
+        // Reset streaming-strip state regardless of whether transcript is present
+        this.assistantPendingTail = '';
         if (transcript) {
-          this.trackAssistantMessage(transcript);
+          const cleanedTranscript = stripBracketedTags(transcript);
+          this.trackAssistantMessage(cleanedTranscript);
           this.wsSend({
             type: 'llm_response_complete',
-            text: transcript,
+            text: cleanedTranscript,
             timestamp: Date.now(),
           });
         }
@@ -349,8 +371,15 @@ export class SessionManager {
   }
 
   private sendSessionUpdate(): void {
-    const { teacherPersona, name, exampleTopics, ttsConfig, code, bcp47 } =
-      this.langConfig;
+    const {
+      teacherPersona,
+      name,
+      exampleTopics,
+      ttsConfig,
+      code,
+      bcp47,
+      disfluencies,
+    } = this.langConfig;
     const memoryContext = this.memory.getContext();
 
     let instructions = `# Context
@@ -367,7 +396,13 @@ export class SessionManager {
 # Communication Style
 - Short, spoken-style sentences — never more than 2 sentences
 - The user's speech comes via speech-to-text, so tolerate transcription errors
-- Ask open-ended questions to get them practicing ${name}`;
+- Ask open-ended questions to get them practicing ${name}
+
+# Voice & expressivity (TTS-2)
+- You may start a turn with ONE English steering tag in brackets, e.g. [speak conversationally], [speak warmly], [speak with light curiosity]. Always English, verb-led, optional.
+- Occasionally (zero or one per turn) include an English non-verbal tag inline: [laugh], [sigh], [clear throat], [gasp], [yawn]. Use only when genuinely warranted — never as decoration.
+- For natural hesitation, use disfluencies in ${name} INLINE (no brackets). Examples: ${disfluencies.join(', ')}. Use 0–2 per turn, only when thinking, never on emphatic statements.
+- Steering and non-verbal tags stay English even though you speak ${name} — they are voice directions, not spoken text. The disfluencies above ARE spoken aloud, so they MUST match ${name}.`;
 
     if (memoryContext) {
       instructions += `\n\n# Recent Conversation Context\n${memoryContext}`;
@@ -437,6 +472,31 @@ export class SessionManager {
       );
       this.lastUserText = '';
     }
+  }
+
+  /**
+   * Strip bracketed control tags from streaming assistant deltas.
+   *
+   * A `[...]` tag may straddle two deltas (e.g. `"...[spe"` then `"ak warmly] ..."`).
+   * We hold back any trailing `[` that hasn't been closed yet, then re-process it
+   * on the next delta. Returns the cleaned text safe to emit as a chunk now —
+   * brackets removed only; whitespace/punctuation normalization is deferred
+   * to the final `.done` pass so chunk concatenation doesn't lose word breaks.
+   */
+  private consumeAssistantDelta(delta: string): string {
+    const combined = this.assistantPendingTail + delta;
+    const lastOpen = combined.lastIndexOf('[');
+    const lastClose = combined.lastIndexOf(']');
+
+    let safe: string;
+    if (lastOpen > lastClose) {
+      safe = combined.slice(0, lastOpen);
+      this.assistantPendingTail = combined.slice(lastOpen);
+    } else {
+      safe = combined;
+      this.assistantPendingTail = '';
+    }
+    return safe.replace(/\[[^\][]*\]/g, '');
   }
 
   private async reconnect(): Promise<void> {

--- a/backend/src/services/websocket-handler.ts
+++ b/backend/src/services/websocket-handler.ts
@@ -127,7 +127,8 @@ export function setupWebSocketHandlers(wss: WebSocketServer): void {
               const audio = await llm.pronounce(
                 msg.text,
                 langConfig.ttsConfig.speakerId,
-                langConfig.bcp47
+                langConfig.bcp47,
+                langConfig.ttsConfig.modelId
               );
               if (audio) {
                 wsSend(ws, {

--- a/backend/src/services/websocket-handler.ts
+++ b/backend/src/services/websocket-handler.ts
@@ -126,7 +126,8 @@ export function setupWebSocketHandlers(wss: WebSocketServer): void {
               const langConfig = getLanguageConfig(languageCode);
               const audio = await llm.pronounce(
                 msg.text,
-                langConfig.ttsConfig.speakerId
+                langConfig.ttsConfig.speakerId,
+                langConfig.bcp47
               );
               if (audio) {
                 wsSend(ws, {

--- a/frontend/public/audio-processor.js
+++ b/frontend/public/audio-processor.js
@@ -1,67 +1,35 @@
 /**
- * AudioWorklet processor for capturing and resampling microphone audio.
- * Resamples to 24kHz PCM16 for Inworld Realtime API.
- * Buffers to 100ms chunks (2400 samples at 24kHz).
+ * AudioWorklet processor — buffers mic samples into 100ms chunks (2400 samples
+ * at 24kHz) and posts them to the main thread as Int16 PCM.
+ *
+ * The capture AudioContext is configured at 24kHz so the worklet receives
+ * samples at the target rate directly — no resampling needed on every quantum.
  */
 class AudioProcessor extends AudioWorkletProcessor {
-  constructor(options) {
+  constructor() {
     super();
-    this.sourceSampleRate = options.processorOptions.sourceSampleRate;
-    this.targetSampleRate = 24000;
-    this.resampleRatio = this.sourceSampleRate / this.targetSampleRate;
-
-    this.inputBuffer = null;
-    this.outputBuffer = [];
-    this.outputBufferSize = 2400; // 100ms at 24kHz
+    this.outputBufferSize = 2400; // 100ms @ 24kHz
+    this.outputBuffer = new Int16Array(this.outputBufferSize);
+    this.outputIndex = 0;
   }
 
   process(inputs) {
-    const inputChannel = inputs[0][0];
-    if (!inputChannel) return true;
+    const inputChannel = inputs[0]?.[0];
+    if (!inputChannel || inputChannel.length === 0) return true;
 
-    // Accumulate input samples
-    const currentLength = this.inputBuffer ? this.inputBuffer.length : 0;
-    const newBuffer = new Float32Array(currentLength + inputChannel.length);
-    if (this.inputBuffer) {
-      newBuffer.set(this.inputBuffer, 0);
-    }
-    newBuffer.set(inputChannel, currentLength);
-    this.inputBuffer = newBuffer;
-
-    // Resample to 24kHz
-    const numOutputSamples = Math.floor(
-      this.inputBuffer.length / this.resampleRatio
-    );
-    if (numOutputSamples === 0) return true;
-
-    const resampledData = new Float32Array(numOutputSamples);
-    for (let i = 0; i < numOutputSamples; i++) {
-      const correspondingInputIndex = i * this.resampleRatio;
-      const lowerIndex = Math.floor(correspondingInputIndex);
-      const upperIndex = Math.ceil(correspondingInputIndex);
-      const interpolationFactor = correspondingInputIndex - lowerIndex;
-
-      const lowerValue = this.inputBuffer[lowerIndex] || 0;
-      const upperValue = this.inputBuffer[upperIndex] || 0;
-
-      resampledData[i] =
-        lowerValue + (upperValue - lowerValue) * interpolationFactor;
-    }
-
-    // Keep unconsumed input samples
-    const consumedInputSamples = numOutputSamples * this.resampleRatio;
-    this.inputBuffer = this.inputBuffer.slice(Math.round(consumedInputSamples));
-
-    // Convert to Int16 and buffer to 100ms chunks
-    for (let i = 0; i < resampledData.length; i++) {
-      this.outputBuffer.push(
-        Math.max(-32768, Math.min(32767, resampledData[i] * 32768))
+    for (let i = 0; i < inputChannel.length; i++) {
+      const sample = inputChannel[i];
+      this.outputBuffer[this.outputIndex++] = Math.max(
+        -32768,
+        Math.min(32767, sample * 32768)
       );
 
-      if (this.outputBuffer.length >= this.outputBufferSize) {
-        const int16Array = new Int16Array(this.outputBuffer);
-        this.port.postMessage(int16Array.buffer, [int16Array.buffer]);
-        this.outputBuffer = [];
+      if (this.outputIndex >= this.outputBufferSize) {
+        // Transfer the underlying buffer to avoid copying.
+        const out = this.outputBuffer.buffer;
+        this.port.postMessage(out, [out]);
+        this.outputBuffer = new Int16Array(this.outputBufferSize);
+        this.outputIndex = 0;
       }
     }
 

--- a/frontend/src/components/WelcomeModal.tsx
+++ b/frontend/src/components/WelcomeModal.tsx
@@ -51,7 +51,7 @@ export function WelcomeModal() {
           <span>Auto flashcards</span>
         </div>
         <div className="welcome-feature">
-          <span>6 languages</span>
+          <span>60+ languages</span>
         </div>
       </div>
       <button className="welcome-cta" onClick={dismiss}>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -22,6 +22,7 @@ import type {
 import { HybridStorage } from '../services/HybridStorage';
 import { WebSocketClient } from '../services/WebSocketClient';
 import { AudioHandler } from '../services/AudioHandler';
+import { AudioPipeline } from '../services/AudioPipeline';
 import { AudioPlayer } from '../services/AudioPlayer';
 import { useAuth } from './AuthContext';
 
@@ -291,11 +292,25 @@ export function AppProvider({ children }: AppProviderProps) {
     []
   );
   const wsClientRef = useRef(wsClientInstance);
-  const audioHandlerInstance = useMemo(() => new AudioHandler(), []);
+  // Shared audio pipeline — one playback context + one master output node so
+  // both AudioPlayer instances and the mic handler can be wired into a single
+  // WebRTC loopback for proper Chrome AEC.
+  const audioPipelineInstance = useMemo(() => new AudioPipeline(), []);
+  const audioPipelineRef = useRef(audioPipelineInstance);
+  const audioHandlerInstance = useMemo(
+    () => new AudioHandler(audioPipelineInstance),
+    [audioPipelineInstance]
+  );
   const audioHandlerRef = useRef(audioHandlerInstance);
-  const audioPlayerInstance = useMemo(() => new AudioPlayer(), []);
+  const audioPlayerInstance = useMemo(
+    () => new AudioPlayer(audioPipelineInstance),
+    [audioPipelineInstance]
+  );
   const audioPlayerRef = useRef(audioPlayerInstance);
-  const ttsAudioPlayerInstance = useMemo(() => new AudioPlayer(), []);
+  const ttsAudioPlayerInstance = useMemo(
+    () => new AudioPlayer(audioPipelineInstance),
+    [audioPipelineInstance]
+  );
   const ttsAudioPlayerRef = useRef(ttsAudioPlayerInstance);
   const hasMigratedRef = useRef(false);
   const conversationsLoadedRef = useRef(false);
@@ -412,11 +427,13 @@ export function AppProvider({ children }: AppProviderProps) {
   useEffect(() => {
     const audioPlayer = audioPlayerRef.current;
     const ttsAudioPlayer = ttsAudioPlayerRef.current;
+    const audioPipeline = audioPipelineRef.current;
     audioPlayer.initialize().catch(console.error);
     ttsAudioPlayer.initialize().catch(console.error);
     return () => {
       audioPlayer.destroy();
       ttsAudioPlayer.destroy();
+      audioPipeline.destroy();
     };
   }, []);
 

--- a/frontend/src/services/AudioHandler.ts
+++ b/frontend/src/services/AudioHandler.ts
@@ -1,19 +1,28 @@
 import type { IOSAudioHandler } from '../types';
+import type { AudioPipeline } from './AudioPipeline';
 
 type EventCallback = (data: string) => void;
 
+const CAPTURE_SAMPLE_RATE = 24000;
+
+/** getUserMedia constraints with the optional Chrome-only AEC hint. */
+type MicConstraints = MediaTrackConstraints & {
+  suppressLocalAudioPlayback?: { ideal: boolean };
+};
+
 export class AudioHandler {
+  private pipeline: AudioPipeline | null;
   private audioContext: AudioContext | null = null;
   private workletNode: AudioWorkletNode | null = null;
-  private scriptProcessor: ScriptProcessorNode | null = null;
   private stream: MediaStream | null = null;
-  private microphone: MediaStreamAudioSourceNode | null = null;
+  private recordSourceNode: MediaStreamAudioSourceNode | null = null;
   private isStreaming = false;
   private listeners = new Map<string, EventCallback[]>();
   private isIOS: boolean;
   private iosHandler: IOSAudioHandler | null;
 
-  constructor() {
+  constructor(pipeline?: AudioPipeline) {
+    this.pipeline = pipeline ?? null;
     this.isIOS =
       /iPad|iPhone|iPod/.test(navigator.userAgent) ||
       (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
@@ -74,7 +83,7 @@ export class AudioHandler {
     try {
       console.log('Starting continuous audio streaming...');
 
-      // Use iOS handler if available
+      // iOS path is unchanged — its native handler manages mic + AEC.
       if (this.isIOS && this.iosHandler) {
         console.log('[AudioHandler] Using iOS audio handler for microphone');
 
@@ -93,41 +102,50 @@ export class AudioHandler {
         }
       }
 
-      // Fallback to standard implementation
-      const constraints = {
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-          channelCount: 1,
-        },
+      const useLoopback = !!this.pipeline;
+      const constraints: MicConstraints = {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+        sampleRate: CAPTURE_SAMPLE_RATE,
       };
+      if (useLoopback) {
+        // Chrome-only hint: tells the browser to NOT apply its built-in playback
+        // suppression so our WebRTC loopback can deliver an explicit reference
+        // signal to the AEC. No-op on browsers that don't recognize it.
+        constraints.suppressLocalAudioPlayback = { ideal: true };
+      }
 
-      this.stream = await navigator.mediaDevices.getUserMedia(constraints);
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: constraints,
+      });
       console.log('Microphone access granted for continuous streaming');
 
+      // Capture AudioContext at 24kHz: matches our target rate so the worklet
+      // doesn't have to resample on every render quantum.
       this.audioContext = new (
         window.AudioContext ||
         (window as unknown as { webkitAudioContext: typeof AudioContext })
           .webkitAudioContext
-      )();
+      )({ sampleRate: CAPTURE_SAMPLE_RATE });
 
       if (this.audioContext.state === 'suspended') {
         console.log('Audio context suspended, resuming...');
         await this.audioContext.resume();
       }
 
-      this.microphone = this.audioContext.createMediaStreamSource(this.stream);
+      // If a pipeline is wired up, route through the WebRTC loopback so Chrome's
+      // AEC sees the playback as a reference signal. Returns the AEC-processed
+      // mic stream — or the original stream if the browser doesn't support it.
+      const recordStream = useLoopback
+        ? await this.pipeline!.enableLoopback(this.stream)
+        : this.stream;
 
-      // Try AudioWorklet first, fallback to ScriptProcessorNode
-      if (this.audioContext.audioWorklet) {
-        console.log('Setting up AudioWorklet processor...');
-        await this.setupAudioWorklet();
-      } else {
-        console.log('AudioWorklet not supported, using ScriptProcessorNode...');
-        this.setupScriptProcessorNode();
-      }
+      this.recordSourceNode =
+        this.audioContext.createMediaStreamSource(recordStream);
 
+      await this.setupAudioWorklet();
       this.isStreaming = true;
       console.log('Continuous audio streaming started');
     } catch (error) {
@@ -137,149 +155,65 @@ export class AudioHandler {
   }
 
   private async setupAudioWorklet(): Promise<void> {
-    if (!this.audioContext || !this.microphone) return;
+    if (!this.audioContext || !this.recordSourceNode) return;
 
-    try {
-      await this.audioContext.audioWorklet.addModule('/audio-processor.js');
-      console.log('AudioWorklet processor loaded');
+    await this.audioContext.audioWorklet.addModule('/audio-processor.js');
+    console.log('AudioWorklet processor loaded');
 
-      this.workletNode = new AudioWorkletNode(
-        this.audioContext,
-        'audio-processor',
-        {
-          processorOptions: {
-            sourceSampleRate: this.audioContext.sampleRate,
-          },
-        }
-      );
-
-      this.workletNode.port.onmessage = (event: MessageEvent) => {
-        if (this.isStreaming) {
-          const int16Buffer = event.data as ArrayBuffer;
-          const base64Audio = btoa(
-            String.fromCharCode(...new Uint8Array(int16Buffer))
-          );
-          this.emit('audioChunk', base64Audio);
-        }
-      };
-
-      this.microphone.connect(this.workletNode);
-      this.workletNode.connect(this.audioContext.destination);
-    } catch (error) {
-      console.error('Error loading AudioWorklet processor:', error);
-      this.setupScriptProcessorNode();
-    }
-  }
-
-  private setupScriptProcessorNode(): void {
-    if (!this.audioContext || !this.microphone) return;
-
-    console.log('Setting up ScriptProcessorNode for compatibility...');
-
-    const bufferSize = 4096;
-    this.scriptProcessor = this.audioContext.createScriptProcessor(
-      bufferSize,
-      1,
-      1
+    this.workletNode = new AudioWorkletNode(
+      this.audioContext,
+      'audio-processor',
+      { channelCount: 1 }
     );
 
-    const targetSampleRate = 24000;
-    const sourceSampleRate = this.audioContext.sampleRate;
-    const resampleRatio = sourceSampleRate / targetSampleRate;
-    let buffer: Float32Array | null = null;
-
-    this.scriptProcessor.onaudioprocess = (event: AudioProcessingEvent) => {
+    this.workletNode.port.onmessage = (event: MessageEvent) => {
       if (this.isStreaming) {
-        const inputData = event.inputBuffer.getChannelData(0);
-
-        // Append new data to the buffer
-        const currentLength = buffer ? buffer.length : 0;
-        const newBuffer = new Float32Array(currentLength + inputData.length);
-        if (buffer) {
-          newBuffer.set(buffer, 0);
-        }
-        newBuffer.set(inputData, currentLength);
-        buffer = newBuffer;
-
-        // Resample to 16kHz
-        const numOutputSamples = Math.floor(buffer.length / resampleRatio);
-        if (numOutputSamples === 0) return;
-
-        const resampledData = new Float32Array(numOutputSamples);
-        for (let i = 0; i < numOutputSamples; i++) {
-          const correspondingInputIndex = i * resampleRatio;
-          const lowerIndex = Math.floor(correspondingInputIndex);
-          const upperIndex = Math.ceil(correspondingInputIndex);
-          const interpolationFactor = correspondingInputIndex - lowerIndex;
-
-          const lowerValue = buffer[lowerIndex] || 0;
-          const upperValue = buffer[upperIndex] || 0;
-
-          resampledData[i] =
-            lowerValue + (upperValue - lowerValue) * interpolationFactor;
-        }
-
-        // Save remainder for next process call
-        const consumedInputSamples = numOutputSamples * resampleRatio;
-        buffer = buffer.slice(Math.round(consumedInputSamples));
-
-        // Convert Float32Array to Int16Array
-        const int16Array = new Int16Array(resampledData.length);
-        for (let i = 0; i < resampledData.length; i++) {
-          int16Array[i] = Math.max(
-            -32768,
-            Math.min(32767, resampledData[i] * 32768)
-          );
-        }
-
+        const int16Buffer = event.data as ArrayBuffer;
         const base64Audio = btoa(
-          String.fromCharCode(...new Uint8Array(int16Array.buffer))
+          String.fromCharCode(...new Uint8Array(int16Buffer))
         );
         this.emit('audioChunk', base64Audio);
       }
     };
 
-    this.microphone.connect(this.scriptProcessor);
-    this.scriptProcessor.connect(this.audioContext.destination);
+    this.recordSourceNode.connect(this.workletNode);
+    this.workletNode.connect(this.audioContext.destination);
   }
 
   stopStreaming(): void {
     console.log('Stopping continuous audio streaming...');
     this.isStreaming = false;
 
-    // Use iOS handler if available
     if (this.isIOS && this.iosHandler) {
       this.iosHandler.stopMicrophone?.();
       console.log('[AudioHandler] iOS microphone stopped');
       return;
     }
 
-    // Standard cleanup
     if (this.workletNode) {
       this.workletNode.port.onmessage = null;
       this.workletNode.disconnect();
       this.workletNode = null;
     }
 
-    if (this.scriptProcessor) {
-      this.scriptProcessor.onaudioprocess = null;
-      this.scriptProcessor.disconnect();
-      this.scriptProcessor = null;
-    }
-
-    if (this.microphone) {
-      this.microphone.disconnect();
-      this.microphone = null;
+    if (this.recordSourceNode) {
+      this.recordSourceNode.disconnect();
+      this.recordSourceNode = null;
     }
 
     if (this.audioContext) {
-      this.audioContext.close();
+      this.audioContext.close().catch(() => {});
       this.audioContext = null;
     }
 
     if (this.stream) {
       this.stream.getTracks().forEach((track) => track.stop());
       this.stream = null;
+    }
+
+    // Tear down the loopback so playback flows back through ctx.destination.
+    if (this.pipeline) {
+      this.pipeline.disableLoopback();
     }
 
     console.log('Continuous audio streaming stopped');

--- a/frontend/src/services/AudioPipeline.ts
+++ b/frontend/src/services/AudioPipeline.ts
@@ -1,0 +1,171 @@
+/**
+ * Owns the shared playback AudioContext and master output node.
+ *
+ * - All TTS playback (streaming voice + flashcard pronunciation) routes through
+ *   `getOutputNode()` so a single node controls where audio actually exits.
+ * - When a mic stream is active, `enableLoopback(stream)` reroutes that output
+ *   through a WebRTC loopback so Chrome's AEC sees the playback as an explicit
+ *   reference signal — and returns the AEC-processed mic stream.
+ * - On Firefox / iOS Safari (no loopback support), playback flows directly to
+ *   `ctx.destination` and the original mic stream is returned unchanged.
+ */
+
+import {
+  WebRtcLoopbackSession,
+  isWebRtcLoopbackSupported,
+} from './WebRtcLoopback';
+
+const PLAYBACK_SAMPLE_RATE = 24000; // matches Inworld TTS-2 output
+
+export class AudioPipeline {
+  private playbackContext: AudioContext | null = null;
+  private outputNode: GainNode | null = null;
+  private loopbackDest: MediaStreamAudioDestinationNode | null = null;
+  private audioElement: HTMLAudioElement | null = null;
+  private loopback: WebRtcLoopbackSession | null = null;
+  private loopbackActive = false;
+
+  /** Lazily create the playback context. Call from a user-gesture handler so
+   *  autoplay policies don't block the first audio frame. */
+  ensurePlaybackContext(): AudioContext {
+    if (this.playbackContext && this.playbackContext.state !== 'closed') {
+      return this.playbackContext;
+    }
+    const Ctor = (window.AudioContext ||
+      (window as unknown as { webkitAudioContext: typeof AudioContext })
+        .webkitAudioContext) as typeof AudioContext;
+    const ctx = new Ctor({ sampleRate: PLAYBACK_SAMPLE_RATE });
+    this.playbackContext = ctx;
+
+    const out = ctx.createGain();
+    out.gain.value = 1;
+    out.connect(ctx.destination);
+    this.outputNode = out;
+
+    if (ctx.state === 'suspended') {
+      ctx.resume().catch(() => {
+        /* gesture expired; will retry on next play */
+      });
+    }
+    return ctx;
+  }
+
+  getPlaybackContext(): AudioContext {
+    return this.ensurePlaybackContext();
+  }
+
+  /** Sink that AudioPlayer instances connect their gain output to. */
+  getOutputNode(): AudioNode {
+    this.ensurePlaybackContext();
+    return this.outputNode!;
+  }
+
+  isLoopbackActive(): boolean {
+    return this.loopbackActive;
+  }
+
+  /**
+   * Wire a WebRTC loopback so Chrome's AEC can use TTS playback as a reference.
+   * Returns the AEC-processed mic stream — or the original mic stream when
+   * loopback isn't supported / setup fails.
+   *
+   * Safe to call multiple times; existing loopback is closed first.
+   */
+  async enableLoopback(micStream: MediaStream): Promise<MediaStream> {
+    if (!isWebRtcLoopbackSupported()) {
+      return micStream;
+    }
+    const ctx = this.ensurePlaybackContext();
+
+    if (!this.loopbackDest) {
+      this.loopbackDest = ctx.createMediaStreamDestination();
+    }
+    if (this.outputNode) {
+      try {
+        this.outputNode.disconnect();
+      } catch {
+        /* not connected */
+      }
+      this.outputNode.connect(this.loopbackDest);
+    }
+
+    if (!this.audioElement) {
+      const el = document.createElement('audio');
+      el.autoplay = true;
+      el.hidden = true;
+      document.body.appendChild(el);
+      this.audioElement = el;
+    }
+
+    if (this.loopback) {
+      this.loopback.close();
+    }
+    this.loopback = new WebRtcLoopbackSession();
+
+    try {
+      await this.loopback.start(micStream, this.loopbackDest.stream);
+
+      if (this.loopback.isPassthrough()) {
+        // Browser doesn't support loopback — restore direct routing.
+        this.disableLoopback();
+        return micStream;
+      }
+
+      this.audioElement.srcObject = this.loopback.getPlaybackStream();
+      this.audioElement.play().catch((err) => {
+        console.warn('[AudioPipeline] <audio>.play() blocked:', err);
+      });
+
+      this.loopbackActive = true;
+      return this.loopback.getRecordStream();
+    } catch (err) {
+      console.warn(
+        '[AudioPipeline] WebRTC loopback failed, falling back to direct path:',
+        err
+      );
+      this.disableLoopback();
+      return micStream;
+    }
+  }
+
+  /** Restore direct routing: outputNode → ctx.destination. Active sources keep playing. */
+  disableLoopback(): void {
+    if (this.audioElement) {
+      this.audioElement.srcObject = null;
+    }
+    if (this.loopback) {
+      this.loopback.close();
+      this.loopback = null;
+    }
+    if (this.outputNode && this.playbackContext) {
+      try {
+        this.outputNode.disconnect();
+      } catch {
+        /* not connected */
+      }
+      this.outputNode.connect(this.playbackContext.destination);
+    }
+    this.loopbackActive = false;
+  }
+
+  destroy(): void {
+    this.disableLoopback();
+    if (this.audioElement) {
+      this.audioElement.remove();
+      this.audioElement = null;
+    }
+    if (this.outputNode) {
+      try {
+        this.outputNode.disconnect();
+      } catch {
+        /* not connected */
+      }
+      this.outputNode = null;
+    }
+    if (this.playbackContext) {
+      this.playbackContext.close().catch(() => {});
+      this.playbackContext = null;
+    }
+    this.loopbackDest = null;
+  }
+}

--- a/frontend/src/services/AudioPlayer.ts
+++ b/frontend/src/services/AudioPlayer.ts
@@ -1,8 +1,10 @@
 import type { IOSAudioHandler } from '../types';
+import type { AudioPipeline } from './AudioPipeline';
 
 type EventCallback = () => void;
 
 export class AudioPlayer {
+  private pipeline: AudioPipeline | null;
   private audioContext: AudioContext | null = null;
   private gainNode: GainNode | null = null;
   private audioQueue: AudioBuffer[] = [];
@@ -17,10 +19,13 @@ export class AudioPlayer {
   private scheduledSources: AudioBufferSourceNode[] = [];
   private scheduleInterval: ReturnType<typeof setInterval> | null = null;
   private readonly SCHEDULE_AHEAD_TIME = 0.1;
-  /** Duration in seconds for fade-in/fade-out via GainNode */
-  private readonly FADE_DURATION = 0.015; // 15ms — smooth enough to kill clicks
+  /** Was 15ms. 25ms preserves the click-free fade while letting Chrome's AEC
+   *  re-converge faster on user interrupt — a non-zero reference signal during
+   *  a long fade distorts the mic input. */
+  private readonly FADE_DURATION = 0.025;
 
-  constructor() {
+  constructor(pipeline?: AudioPipeline) {
+    this.pipeline = pipeline ?? null;
     this.isIOS =
       /iPad|iPhone|iPod/.test(navigator.userAgent) ||
       (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
@@ -47,11 +52,21 @@ export class AudioPlayer {
 
   async initialize(_sampleRate?: number): Promise<void> {
     try {
-      // Do NOT pass sampleRate to AudioContext — let it use the hardware's
-      // native rate (typically 48 kHz). Forcing a non-native rate (e.g. 24 kHz)
-      // makes the browser resample *all* output, which can introduce artifacts.
-      // Instead, each AudioBuffer declares its own sample rate via createBuffer()
-      // and the AudioContext resamples per-buffer transparently.
+      if (this.pipeline && !this.isIOS) {
+        // Share the pipeline's playback context so all audio routes through one
+        // master output node — required for the WebRTC loopback AEC to see a
+        // unified reference signal.
+        this.audioContext = this.pipeline.getPlaybackContext();
+        if (this.audioContext.state === 'suspended') {
+          await this.audioContext.resume();
+        }
+        this.gainNode = this.audioContext.createGain();
+        this.gainNode.gain.value = 0;
+        this.gainNode.connect(this.pipeline.getOutputNode());
+        return;
+      }
+
+      // iOS / no-pipeline fallback: each player owns its own context.
       this.audioContext = new (
         window.AudioContext ||
         (window as unknown as { webkitAudioContext: typeof AudioContext })
@@ -62,12 +77,9 @@ export class AudioPlayer {
         await this.audioContext.resume();
       }
 
-      // Create a GainNode for smooth fade-in/out — all audio routes through this
       this.gainNode = this.audioContext.createGain();
-      this.gainNode.gain.value = 0; // Start silent
+      this.gainNode.gain.value = 0;
       this.gainNode.connect(this.audioContext.destination);
-
-      // Audio player initialized
     } catch (error) {
       console.error('Failed to initialize audio player:', error);
       throw error;
@@ -92,7 +104,6 @@ export class AudioPlayer {
       this.endStreaming();
     }, 1000);
 
-    // Use iOS handler if available
     if (this.isIOS && this.iosHandler) {
       try {
         await this.iosHandler.playAudioChunk?.(base64Audio, isLastChunk);
@@ -109,13 +120,11 @@ export class AudioPlayer {
       }
     }
 
-    // Standard implementation
     if (!this.audioContext || !this.gainNode) {
       await this.initialize(sampleRate);
     }
 
     try {
-      // Decode base64 to binary
       const binaryString = atob(base64Audio);
       let bytes = new Uint8Array(binaryString.length);
 
@@ -135,7 +144,6 @@ export class AudioPlayer {
         bytes = bytes.slice(44);
       }
 
-      // Create audio buffer (no per-chunk fade — GainNode handles envelope)
       const audioBuffer = await this.createAudioBuffer(
         bytes.buffer.slice(
           bytes.byteOffset,
@@ -147,7 +155,6 @@ export class AudioPlayer {
 
       this.audioQueue.push(audioBuffer);
 
-      // Start playback immediately if not already playing
       if (!this.isPlaying && !this.isStartingPlayback) {
         this.isStartingPlayback = true;
         this.fadeIn();
@@ -190,7 +197,6 @@ export class AudioPlayer {
 
       return audioBuffer;
     } else {
-      // Int16 PCM format
       const int16Array = new Int16Array(arrayBuffer);
       numSamples = int16Array.length;
 
@@ -248,7 +254,6 @@ export class AudioPlayer {
       this.nextStartTime = currentTime;
     }
 
-    // Schedule buffers that should start within SCHEDULE_AHEAD_TIME
     while (
       this.audioQueue.length > 0 &&
       this.nextStartTime < currentTime + this.SCHEDULE_AHEAD_TIME
@@ -264,7 +269,6 @@ export class AudioPlayer {
 
     const source = this.audioContext.createBufferSource();
     source.buffer = audioBuffer;
-    // Route through GainNode instead of directly to destination
     source.connect(this.gainNode);
 
     this.scheduledSources.push(source);
@@ -276,7 +280,6 @@ export class AudioPlayer {
       }
 
       if (this.scheduledSources.length === 0 && this.audioQueue.length === 0) {
-        // Fade out at the natural end of playback to prevent a click
         this.fadeOut(() => {
           this.isPlaying = false;
           this.stopScheduleInterval();
@@ -330,13 +333,11 @@ export class AudioPlayer {
   }
 
   private stopInternal(immediate: boolean): void {
-    // Clear stream timeout
     if (this.streamTimeout) {
       clearTimeout(this.streamTimeout);
       this.streamTimeout = null;
     }
 
-    // Use iOS handler if available
     if (this.isIOS && this.iosHandler) {
       this.iosHandler.stopAudioPlayback?.();
       this.isPlaying = false;
@@ -353,7 +354,7 @@ export class AudioPlayer {
           source.stop();
           source.disconnect();
         } catch {
-          // Source may have already ended
+          /* already stopped */
         }
       }
       this.scheduledSources = [];
@@ -376,14 +377,12 @@ export class AudioPlayer {
     };
 
     if (immediate) {
-      // Kill instantly — set gain to 0 with no ramp
       if (this.gainNode && this.audioContext) {
         this.gainNode.gain.cancelScheduledValues(this.audioContext.currentTime);
         this.gainNode.gain.setValueAtTime(0, this.audioContext.currentTime);
       }
       killSources();
     } else {
-      // Graceful fade out
       this.fadeOut(killSources);
     }
   }
@@ -392,11 +391,21 @@ export class AudioPlayer {
     this.stop();
     this.stopScheduleInterval();
 
-    if (this.audioContext) {
-      this.audioContext.close();
-      this.audioContext = null;
+    // Disconnect our gain node, but only close the context if we own it.
+    // When using a shared AudioPipeline, the pipeline owns the context and
+    // closing it here would break the other AudioPlayer.
+    if (this.gainNode) {
+      try {
+        this.gainNode.disconnect();
+      } catch {
+        /* not connected */
+      }
+      this.gainNode = null;
     }
-    this.gainNode = null;
+    if (this.audioContext && !this.pipeline) {
+      this.audioContext.close().catch(() => {});
+    }
+    this.audioContext = null;
 
     this.listeners.clear();
   }
@@ -407,8 +416,6 @@ export class AudioPlayer {
       this.streamTimeout = null;
     }
 
-    // If sources are still scheduled, onended handlers will fade out + emit.
-    // If nothing is playing or queued, emit finished immediately.
     if (this.scheduledSources.length === 0 && this.audioQueue.length === 0) {
       if (this.isPlaying) {
         this.fadeOut(() => {
@@ -418,6 +425,5 @@ export class AudioPlayer {
         });
       }
     }
-    // Otherwise: let the last source's onended handle cleanup.
   }
 }

--- a/frontend/src/services/WebRtcLoopback.ts
+++ b/frontend/src/services/WebRtcLoopback.ts
@@ -1,0 +1,158 @@
+/**
+ * Local WebRTC loopback that gives Chrome's AEC an explicit reference signal.
+ *
+ * Two RTCPeerConnections are connected locally via ICE. The mic stream is fed
+ * into the "client" peer and the playback (TTS) stream into the "server" peer.
+ * Chrome's WebRTC AEC sees the playback as the reference and applies proper
+ * echo cancellation to the mic signal, without damaging speech when there is
+ * no actual echo (headphones / low-volume speakers).
+ *
+ * Ported from the inworld-golden-demo pattern (originally from inworld-web-sdk's
+ * GrpcWebRtcLoopbackBiDiSession).
+ */
+
+function isIOSMobile(): boolean {
+  if (typeof navigator === 'undefined' || typeof document === 'undefined')
+    return false;
+  const ua = navigator.userAgent;
+  return (
+    /iPad|iPhone|iPod/.test(ua) ||
+    (ua.includes('Mac') && 'ontouchend' in document)
+  );
+}
+
+function isFirefox(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return navigator.userAgent.indexOf('Firefox') !== -1;
+}
+
+export function isWebRtcLoopbackSupported(): boolean {
+  return (
+    typeof RTCPeerConnection !== 'undefined' && !isIOSMobile() && !isFirefox()
+  );
+}
+
+export class WebRtcLoopbackSession {
+  private static OFFER_OPTIONS: RTCOfferOptions = {
+    offerToReceiveAudio: true,
+    offerToReceiveVideo: false,
+  };
+
+  private rtcServerConnection?: RTCPeerConnection;
+  private rtcClientConnection?: RTCPeerConnection;
+  private loopbackRecordStream?: MediaStream;
+  private loopbackPlaybackStream?: MediaStream;
+  private passthrough = false;
+
+  /**
+   * @param inputStream  Mic MediaStream from getUserMedia
+   * @param outputStream Playback MediaStream from a MediaStreamAudioDestinationNode
+   */
+  async start(
+    inputStream: MediaStream,
+    outputStream: MediaStream
+  ): Promise<void> {
+    if (!isWebRtcLoopbackSupported()) {
+      this.loopbackRecordStream = inputStream;
+      this.loopbackPlaybackStream = outputStream;
+      this.passthrough = true;
+      return;
+    }
+
+    this.loopbackRecordStream = new MediaStream();
+    this.loopbackPlaybackStream = new MediaStream();
+
+    this.rtcServerConnection = new RTCPeerConnection();
+    this.rtcClientConnection = new RTCPeerConnection();
+
+    this.rtcServerConnection.onicecandidate = (e) => {
+      if (e.candidate && this.rtcClientConnection) {
+        void this.rtcClientConnection
+          .addIceCandidate(new RTCIceCandidate(e.candidate))
+          .catch(() => {});
+      }
+    };
+    this.rtcClientConnection.onicecandidate = (e) => {
+      if (e.candidate && this.rtcServerConnection) {
+        void this.rtcServerConnection
+          .addIceCandidate(new RTCIceCandidate(e.candidate))
+          .catch(() => {});
+      }
+    };
+
+    this.rtcClientConnection.ontrack = (e) =>
+      this.loopbackPlaybackStream?.addTrack(e.track);
+    this.rtcServerConnection.ontrack = (e) =>
+      this.loopbackRecordStream?.addTrack(e.track);
+
+    inputStream
+      .getTracks()
+      .forEach((track) => this.rtcClientConnection?.addTrack(track));
+    outputStream
+      .getTracks()
+      .forEach((track) => this.rtcServerConnection?.addTrack(track));
+
+    const offer = await this.rtcServerConnection.createOffer(
+      WebRtcLoopbackSession.OFFER_OPTIONS
+    );
+    await this.rtcServerConnection.setLocalDescription(offer);
+    await this.rtcClientConnection.setRemoteDescription(offer);
+
+    const answer = await this.rtcClientConnection.createAnswer();
+    await this.rtcClientConnection.setLocalDescription(answer);
+    await this.rtcServerConnection.setRemoteDescription(answer);
+
+    await Promise.all([
+      waitForAudioTrack(this.loopbackRecordStream),
+      waitForAudioTrack(this.loopbackPlaybackStream),
+    ]);
+  }
+
+  /** AEC-processed mic stream — feed to AudioWorklet for encoding. */
+  getRecordStream(): MediaStream {
+    if (!this.loopbackRecordStream)
+      throw new Error('WebRtcLoopbackSession: call start() first');
+    return this.loopbackRecordStream;
+  }
+
+  /** Playback stream — route to an <audio> element for speaker output. */
+  getPlaybackStream(): MediaStream {
+    if (!this.loopbackPlaybackStream)
+      throw new Error('WebRtcLoopbackSession: call start() first');
+    return this.loopbackPlaybackStream;
+  }
+
+  isPassthrough(): boolean {
+    return this.passthrough;
+  }
+
+  close(): void {
+    this.rtcClientConnection?.close();
+    this.rtcClientConnection = undefined;
+    this.rtcServerConnection?.close();
+    this.rtcServerConnection = undefined;
+    this.loopbackRecordStream = undefined;
+    this.loopbackPlaybackStream = undefined;
+    this.passthrough = false;
+  }
+}
+
+const TRACK_WAIT_TIMEOUT_MS = 5000;
+
+function waitForAudioTrack(stream: MediaStream): Promise<void> {
+  if (stream.getAudioTracks().length > 0) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      stream.removeEventListener('addtrack', onTrack);
+      reject(new Error('Timed out waiting for audio track on loopback stream'));
+    }, TRACK_WAIT_TIMEOUT_MS);
+    const onTrack = () => {
+      if (stream.getAudioTracks().length > 0) {
+        clearTimeout(timer);
+        stream.removeEventListener('addtrack', onTrack);
+        resolve();
+      }
+    };
+    stream.addEventListener('addtrack', onTrack);
+  });
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -178,12 +178,14 @@ body {
     top: calc(100% + 0.5rem);
     left: 0;
     right: 0;
+    max-height: 60vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     background: var(--bg-card);
     border: 1px solid var(--border-warm);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-lg);
     z-index: 100;
-    overflow: hidden;
 }
 
 .sidebar-close-button {


### PR DESCRIPTION
## Summary
- **TTS → `inworld-tts-2`** everywhere (realtime + REST). Language is supplied per-call: BCP-47 via `session.providerData.tts.language` for the realtime session, and the REST `language` field for Anki batch + flashcard pronunciation. Voices stay cross-lingual but grounded in the target locale.
- **STT → `soniox/stt-rt-v4`** with the ISO 639-1 language hint via `transcription.language`. Soniox emits **cumulative** partial deltas (each delta is the full transcript so far) — switched the buffer logic from append to replace so partials no longer render as `"hi hi there hi there this..."`.
- **+54 languages**: reshuffled `LanguageConfig` to make BCP-47 the canonical form (dropped `sttLanguageCode` and `ttsConfig.languageCode`). Added all Soniox-supported languages with alternating Sarah/Jason TTS-2 voices and templated personas. The 6 existing curated personas/voices/topics are preserved as-is.
- **Frontend polish**: welcome modal now reads "60+ languages"; the sidebar language dropdown scrolls (`max-height: 60vh`, `overflow-y: auto`, `overscroll-behavior: contain`).

## Test plan
- [x] `cd backend && npx tsc --noEmit`
- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd backend && npx vitest run` — all 60 tests pass
- [ ] Pick **Spanish** (existing) → conversation works, Señor Gael Herrera persona + Rafael voice
- [ ] Pick **Finnish** (new) → Sarah/Jason speaks Finnish; Soniox transcribes Finnish speech
- [ ] Mid-session language switch → fresh `session.update` with new BCP-47
- [ ] Watch backend logs for `inworld_error_event` (TTS-2 / Soniox surface here)
- [ ] Anki export with a non-English deck — verify generated WAVs sound right