### PR TITLE
fix(deps): bump shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.2"
+  },
+  "overrides": {
+    "shell-quote@<1.8.4": "1.8.4"
   }
 }


### PR DESCRIPTION
## What
Pins **shell-quote** to **1.8.4** (was 1.8.3) via an `overrides` entry on the root `package.json`, and regenerates the root `package-lock.json`.

```json
"overrides": {
  "shell-quote@<1.8.4": "1.8.4"
}
```

## Why
shell-quote `<1.8.4` carries a CRITICAL command-injection advisory, **CVE-2026-9277** (`quote()` mishandles line terminators in an object token's `.op` field, allowing command separation in POSIX shells). Fixed upstream in 1.8.4.

## Scope / safety
- Override is scoped to vulnerable (`<1.8.4`) instances only, so it is a no-op once the tree is clean.
- Root lockfile diff is contained to the shell-quote version/resolved/integrity (6 lines, 2 files). The `backend/` and `frontend/` lockfiles do not contain shell-quote and are untouched.
- Patch bump of a transitive dev tool; production build and runtime are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)